### PR TITLE
Update Prometheus configuration in README for improved clarity and consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,13 @@ GET /metrics
 Point your Prometheus server to scrape this endpoint at intervals (e.g., every 15s or 30s). For example, in `prometheus.yml`:
 
 ```yaml
+global:
+   scrape_interval: 15s
+
 scrape_configs:
-  - job_name: 'librechat_exporter'
-    scrape_interval: 15s
-    static_configs:
-      - targets: ['localhost:9087']
+   - job_name: 'librechat-exporter'
+     static_configs:
+        - targets: ['exporter:9087']
 ```
 
 ---
@@ -139,10 +141,13 @@ scrape_configs:
     - Ensure your `prometheus.yml` includes the `scrape_configs` pointing to the exporter.
     - Example:
       ```yaml
+      global:
+          scrape_interval: 15s
+      
       scrape_configs:
-        - job_name: 'librechat_exporter'
-          static_configs:
-            - targets: ['localhost:9087']
+          - job_name: 'librechat-exporter'
+            static_configs:
+                - targets: ['exporter:9087']
       ```
 
 2. **Grafana**:


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to improve the configuration examples for Prometheus. The changes ensure consistency and clarity in the configuration.

Updates to Prometheus configuration examples:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L127-R133): Modified the `scrape_configs` section to include a `global` scrape interval and changed the job name format from `librechat_exporter` to `librechat-exporter`. Additionally, updated the target from `localhost:9087` to `exporter:9087`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L127-R133) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R144-R150)