### PR TITLE
Refactor CI/CD pipeline to support multi-architecture Docker builds for Linux and Windows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,7 +9,7 @@ permissions:
   packages: write
 
 jobs:
-  docker_build:
+  build_linux:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -25,20 +25,49 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image (latest)
-        if: github.ref == 'refs/heads/main'
+      - name: Build and push Linux image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository }}:latest
+          platforms: linux/amd64,linux/arm64
+          # Append "-linux" to the tag so we can differentiate when merging the manifest
+          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}-linux
 
-      - name: Build and push Docker image (version tag)
-        if: startsWith(github.ref, 'refs/tags/')
+  build_windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Windows image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          platforms: windows/amd64
+          # Append "-windows" to the tag so we can differentiate when merging the manifest
+          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}-windows
+
+  manifest:
+    runs-on: ubuntu-latest
+    needs: [build_linux, build_windows]
+    steps:
+      - name: Create and push multi-arch manifest
+        run: |
+          docker manifest create ghcr.io/${{ github.repository }}:${{ github.ref_name }} \
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}-linux \
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}-windows
+          docker manifest push ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   exporter:
     image: ghcr.io/rubentalstra/librechat-prom-exporter:latest


### PR DESCRIPTION
This pull request includes significant updates to the CI/CD workflow configuration and a minor change to the `docker-compose.yml` file. The most important changes involve renaming and restructuring the build jobs, supporting multi-architecture Docker images, and creating a multi-arch manifest.

Improvements to CI/CD workflow:

* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L12-R12): Renamed `docker_build` job to `build_linux` and added a new `build_windows` job to support building and pushing Docker images for both Linux and Windows platforms. [[1]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L12-R12) [[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L28-R73)
* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L28-R73): Added a `manifest` job that creates and pushes a multi-architecture manifest to combine the Linux and Windows images.

Minor changes:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L1-L2): Removed the version specification at the top of the file.