### PR TITLE
Update Windows build environment to use windows-2019 in CI/CD pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -36,7 +36,7 @@ jobs:
           tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}-linux
 
   build_windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request includes a change to the `jobs:` section in the `.github/workflows/cd.yml` file. The change updates the runner environment for the `build_windows` job.

* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L39-R39): Changed the runner environment for the `build_windows` job from `windows-latest` to `windows-2019`.