### PR TITLE
Refactor CI/CD pipeline to consolidate Linux and Windows builds into a single multi-architecture build step

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,7 +9,7 @@ permissions:
   packages: write
 
 jobs:
-  build_linux:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -25,49 +25,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Linux image
+      - name: Build and push multi-arch Linux image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
-          # Append "-linux" to the tag so we can differentiate when merging the manifest
-          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}-linux
-
-  build_windows:
-    runs-on: windows-2019
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push Windows image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          push: true
-          platforms: windows/amd64
-          # Append "-windows" to the tag so we can differentiate when merging the manifest
-          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}-windows
-
-  manifest:
-    runs-on: ubuntu-latest
-    needs: [build_linux, build_windows]
-    steps:
-      - name: Create and push multi-arch manifest
-        run: |
-          docker manifest create ghcr.io/${{ github.repository }}:${{ github.ref_name }} \
-            ghcr.io/${{ github.repository }}:${{ github.ref_name }}-linux \
-            ghcr.io/${{ github.repository }}:${{ github.ref_name }}-windows
-          docker manifest push ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}


### PR DESCRIPTION
This pull request includes significant changes to the GitHub Actions workflow configuration to streamline the build process and support multi-architecture Docker images. The most important changes include merging the Linux and Windows build jobs into a single multi-architecture build job and removing the manifest creation job.

Improvements to the build process:

* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L12-R12): Renamed the `build_linux` job to `build` and updated it to build and push multi-architecture Docker images for both Linux and Windows. [[1]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L12-R12) [[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L28-R35)
* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L28-R35): Removed the separate Windows build job and the manifest creation job, simplifying the workflow by consolidating all build steps into a single job.