### PR TITLE
Enhance CI/CD pipeline to build and push Docker images with latest and version tags for multi-architecture support

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,7 +25,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push multi-arch Linux image
+      - name: Build and push Docker image (latest)
+        if: github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ghcr.io/${{ github.repository }}:latest
+
+      - name: Build and push Docker image (version tag)
+        if: startsWith(github.ref, 'refs/tags/')
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
This pull request includes updates to the continuous deployment workflow in the `.github/workflows/cd.yml` file to improve the Docker image build and push process.

Improvements to Docker image build and push process:

* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L28-R39): Changed the job name to "Build and push Docker image (latest)" and added a condition to only run this job on the `main` branch. Updated the Docker build-push action to use version 6 and specified platforms and tags for the Docker image.
* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L28-R39): Added a new job named "Build and push Docker image (version tag)" that runs when a tag is pushed, using the same Docker build-push action and settings.