### PR TITLE
Fix/dashboard grafana

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,10 +15,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Check for source changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            src:
+              - 'src/**'
+            dockerfile:
+              - 'Dockerfile'
+
       - name: Set up Docker Buildx
+        if: steps.changes.outputs.src == 'true' || steps.changes.outputs.dockerfile == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
+        if: steps.changes.outputs.src == 'true' || steps.changes.outputs.dockerfile == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -26,7 +38,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image (latest)
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && (steps.changes.outputs.src == 'true' || steps.changes.outputs.dockerfile == 'true')
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -36,7 +48,7 @@ jobs:
           tags: ghcr.io/${{ github.repository }}:latest
 
       - name: Build and push Docker image (version tag)
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && (steps.changes.outputs.src == 'true' || steps.changes.outputs.dockerfile == 'true')
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/librechat-exporter-dashboard.json
+++ b/librechat-exporter-dashboard.json
@@ -36,7 +36,7 @@
   "timezone": "",
   "title": "LibreChat Exporter Dashboard",
   "uid": "librechat-exporter-dashboard",
-  "version": 6,
+  "version": 7,
   "weekStart": "",
   "panels": [
     {
@@ -750,17 +750,17 @@
       "pluginVersion": "2.0.1",
       "targets": [
         {
-          "expr": "increase(librechat_model_usage_count[$__range])",
+          "expr": "librechat_model_usage_count",
           "legendFormat": "{{model}}",
           "refId": "A"
         },
         {
-          "expr": "increase(librechat_agent_usage_count[$__range])",
+          "expr": "librechat_agent_usage_count",
           "legendFormat": "{{agent}}",
           "refId": "B"
         },
         {
-          "expr": "increase(librechat_assistant_usage_count[$__range])",
+          "expr": "librechat_assistant_usage_count",
           "legendFormat": "{{assistant}}",
           "refId": "C"
         }
@@ -834,12 +834,12 @@
       },
       "targets": [
         {
-          "expr": "increase(librechat_agent_usage_count[$__range])",
+          "expr": "librechat_agent_usage_count",
           "legendFormat": "{{agent}}",
           "refId": "A"
         },
         {
-          "expr": "increase(librechat_assistant_usage_count[$__range])",
+          "expr": "librechat_assistant_usage_count",
           "legendFormat": "{{assistant}}",
           "refId": "B"
         }


### PR DESCRIPTION
This pull request includes updates to the CI/CD workflow and changes to the LibreChat Exporter Dashboard configuration. The most important changes are focused on optimizing the CI/CD process and simplifying the dashboard expressions.

### CI/CD Workflow Enhancements:

* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R18-R41): Added a check for source and Dockerfile changes using `dorny/paths-filter@v3` before setting up Docker Buildx, logging into the GitHub Container Registry, and building and pushing Docker images. This ensures that Docker-related steps are only executed when relevant files are modified. [[1]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R18-R41) [[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L39-R51)

### Dashboard Configuration Simplification:

* [`librechat-exporter-dashboard.json`](diffhunk://#diff-47fe27350b88d9bdebdde3efd67ffdb39f277d6cda086eda2bec45d19c6c4af1L39-R39): Updated the dashboard version from 6 to 7.
* [`librechat-exporter-dashboard.json`](diffhunk://#diff-47fe27350b88d9bdebdde3efd67ffdb39f277d6cda086eda2bec45d19c6c4af1L753-R763): Simplified Prometheus expressions by removing the `increase` function from `librechat_model_usage_count`, `librechat_agent_usage_count`, and `librechat_assistant_usage_count` metrics. This change affects multiple panels within the dashboard. [[1]](diffhunk://#diff-47fe27350b88d9bdebdde3efd67ffdb39f277d6cda086eda2bec45d19c6c4af1L753-R763) [[2]](diffhunk://#diff-47fe27350b88d9bdebdde3efd67ffdb39f277d6cda086eda2bec45d19c6c4af1L837-R842)