### PR TITLE
Fix/cd tags

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,6 +37,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Build and push image when pushing to main branch (only "latest")
       - name: Build and push Docker image (latest)
         if: github.ref == 'refs/heads/main' && (steps.changes.outputs.src == 'true' || steps.changes.outputs.dockerfile == 'true')
         uses: docker/build-push-action@v6
@@ -47,12 +48,16 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ghcr.io/${{ github.repository }}:latest
 
+      # Build and push image when pushing a version tag.
+      # This step tags the image with both the version (e.g. "v1.2.3") and "latest".
       - name: Build and push Docker image (version tag)
-        if: startsWith(github.ref, 'refs/tags/') && (steps.changes.outputs.src == 'true' || steps.changes.outputs.dockerfile == 'true')
+        if: startsWith(github.ref, 'refs/tags/v') && (steps.changes.outputs.src == 'true' || steps.changes.outputs.dockerfile == 'true')
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,15 +15,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Check for source changes
-        id: changes
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            src:
-              - 'src/**'
-            dockerfile:
-              - 'Dockerfile'
+#      - name: Check for source changes
+#        id: changes
+#        uses: dorny/paths-filter@v3
+#        with:
+#          filters: |
+#            src:
+#              - 'src/**'
+#            dockerfile:
+#              - 'Dockerfile'
 
       - name: Set up Docker Buildx
         if: steps.changes.outputs.src == 'true' || steps.changes.outputs.dockerfile == 'true'
@@ -37,7 +37,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Build and push image when pushing to main branch (only "latest")
       - name: Build and push Docker image (latest)
         if: github.ref == 'refs/heads/main' && (steps.changes.outputs.src == 'true' || steps.changes.outputs.dockerfile == 'true')
         uses: docker/build-push-action@v6
@@ -48,8 +47,6 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ghcr.io/${{ github.repository }}:latest
 
-      # Build and push image when pushing a version tag.
-      # This step tags the image with both the version (e.g. "v1.2.3") and "latest".
       - name: Build and push Docker image (version tag)
         if: startsWith(github.ref, 'refs/tags/v') && (steps.changes.outputs.src == 'true' || steps.changes.outputs.dockerfile == 'true')
         uses: docker/build-push-action@v6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librechat-prom-exporter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librechat-prom-exporter",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "ISC",
       "dependencies": {
         "express": "^4.21.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-prom-exporter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Prometheus exporter for LibreChat metrics",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This pull request includes several changes to the CI/CD workflow and a version bump in the `package.json` file. The most important changes include commenting out the source changes check, updating the condition for building and pushing Docker images, and updating the Docker image tags.

CI/CD workflow updates:

* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L18-R26): Commented out the steps for checking source changes using `dorny/paths-filter@v3`.
* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L51-R60): Updated the condition for building and pushing Docker images to check for tags starting with 'v'.
* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L51-R60): Updated the Docker image tags to include both the version tag and the `latest` tag.

Version bump:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `0.2.0` to `0.2.1`.