### PR TITLE
Bump dependencies and update package versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,25 +9,25 @@
       "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
-        "@librechat/data-schemas": "^0.0.6",
+        "@librechat/data-schemas": "^0.0.7",
         "express": "^4.21.2",
         "librechat-data-provider": "^0.7.6998",
-        "mongoose": "^8.13.2",
+        "mongoose": "^8.15.0",
         "prom-client": "^15.1.3"
       },
       "devDependencies": {
-        "@eslint/compat": "^1.2.8",
+        "@eslint/compat": "^1.2.9",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "^9.24.0",
+        "@eslint/js": "^9.27.0",
         "@microsoft/eslint-formatter-sarif": "^3.1.0",
-        "@types/express": "^4.17.21",
+        "@types/express": "^4.17.22",
         "@types/node": "^22.15.21",
         "@typescript-eslint/eslint-plugin": "^8.32.1",
         "@typescript-eslint/parser": "^8.32.1",
-        "eslint": "^9.24.0",
+        "eslint": "^9.27.0",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jest": "^28.11.0",
-        "globals": "^16.0.0",
+        "globals": "^16.1.0",
         "typescript": "^5.8.3"
       }
     },
@@ -61,9 +61,9 @@
       }
     },
     "node_modules/@eslint/compat": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.2.8.tgz",
-      "integrity": "sha512-LqCYHdWL/QqKIJuZ/ucMAv8d4luKGs4oCPgpt8mWztQAtPrHfXKQ/XAUc8ljCHAfJCn6SvkpTcGt5Tsh8saowA==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.2.9.tgz",
+      "integrity": "sha512-gCdSY54n7k+driCadyMNv8JSPzYLeDVM/ikZRtvtROBpRdFSkS8W9A82MqsaY7lZuwL0wiapgD0NT1xT0hyJsA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -128,9 +128,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
-      "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
+      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -202,13 +202,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.24.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.24.0.tgz",
-      "integrity": "sha512-uIY/y3z0uvOGX8cp1C2fiC4+ZmBhp6yZWkojtHL1YEMnRt1Y63HB9TM17proGEmeG7HeUY+UP36F0aknKYTpYA==",
+      "version": "9.27.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.27.0.tgz",
+      "integrity": "sha512-G5JD9Tu5HJEu4z2Uo4aHY2sLV64B7CDMXxFzqzjl3NKd6RVzSXNoE80jk7Y0lJkTTkjiIhBAqmlYwjuBY3tvpA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -222,13 +225,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
-      "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
+      "integrity": "sha512-0J+zgWxHN+xXONWIyPWKFMgVuJoZuGiIFu8yxk7RJjxkzpGmyja5wRFqZIVtjDVOQpV+Rw0iOAjYPE2eQyjr0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.12.0",
+        "@eslint/core": "^0.14.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -349,16 +352,26 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@keyv/serialize": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.0.3.tgz",
+      "integrity": "sha512-qnEovoOp5Np2JDGonIDL6Ayihw0RhnRh6vxPuHo4RDn1UOzwEo4AeIfpL6UGIrsceWrCMiVPgwRjbHu4vYFc3g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer": "^6.0.3"
+      }
+    },
     "node_modules/@librechat/data-schemas": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@librechat/data-schemas/-/data-schemas-0.0.6.tgz",
-      "integrity": "sha512-c72wPoOwAGYU0XFmIe4nDbuEmnD3+FN+SEK+cNFrKnfjo6SbTNJXElVbF9FqmduoXByIn9H7Xq14QA66hu349w==",
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@librechat/data-schemas/-/data-schemas-0.0.7.tgz",
+      "integrity": "sha512-RiuyBqCHr5+yb8bmbFH1rddeXAizaS1XpyiJwmOxrAFlcjy97MJtK47LmKTvomBdA9bUQwb3eWXAYYUGO0B1UA==",
       "license": "MIT",
       "dependencies": {
         "mongoose": "^8.12.1"
       },
       "peerDependencies": {
-        "keyv": "^4.5.4"
+        "keyv": "^5.3.2"
       }
     },
     "node_modules/@microsoft/eslint-formatter-sarif": {
@@ -571,6 +584,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@microsoft/eslint-formatter-sarif/node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/@microsoft/eslint-formatter-sarif/node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -715,9 +738,9 @@
       "license": "MIT"
     },
     "node_modules/@types/express": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
-      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "version": "4.17.22",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.22.tgz",
+      "integrity": "sha512-eZUmSnhRX9YRSkplpz0N+k6NljUUn5l3EWZIKZvYzhvMphEuNiyyy1viH/ejgt66JWgALwC/gtSUAeQKtSwW/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1300,6 +1323,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/bintrees": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
@@ -1375,6 +1419,31 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/bytes": {
@@ -1897,20 +1966,20 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.24.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.24.0.tgz",
-      "integrity": "sha512-eh/jxIEJyZrvbWRe4XuVclLPDYSYYYgLy5zXGGxD6j8zjSAxFEzI2fL/8xNq6O2yKqVt+eF2YhV+hxjV6UKXwQ==",
+      "version": "9.27.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.27.0.tgz",
+      "integrity": "sha512-ixRawFQuMB9DZ7fjU3iGGganFDp3+45bPOdaRurcFHSXO1e/sYwUX/FtQZpLZJR6SjMoJH8hR2pPEAfDyCoU2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.20.0",
-        "@eslint/config-helpers": "^0.2.0",
-        "@eslint/core": "^0.12.0",
+        "@eslint/config-helpers": "^0.2.1",
+        "@eslint/core": "^0.14.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.24.0",
-        "@eslint/plugin-kit": "^0.2.7",
+        "@eslint/js": "9.27.0",
+        "@eslint/plugin-kit": "^0.3.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
@@ -2476,6 +2545,16 @@
         "node": ">=16"
       }
     },
+    "node_modules/flat-cache/node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/flatted": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
@@ -2714,9 +2793,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.0.0.tgz",
-      "integrity": "sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A==",
+      "version": "16.1.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.1.0.tgz",
+      "integrity": "sha512-aibexHNbb/jiUSObBgpHLj+sIuUmJnYcgXBlrfsiDZ9rt4aF2TFRbyLgZ2iFQuVZ1K5Mx3FVkbKRSgKrbK3K2g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2880,6 +2959,27 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -3395,6 +3495,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -3434,12 +3535,13 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.3.3.tgz",
+      "integrity": "sha512-Rwu4+nXI9fqcxiEHtbkvoes2X+QfkTRo1TMkPfwzipGsJlJO/z69vqB4FNl9xJ3xCpAcbkvmEabZfPzrwN3+gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "json-buffer": "3.0.1"
+        "@keyv/serialize": "^1.0.3"
       }
     },
     "node_modules/levn": {
@@ -3639,9 +3741,9 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.15.0.tgz",
-      "integrity": "sha512-ifBhQ0rRzHDzqp9jAQP6OwHSH7dbYIQjD3SbJs9YYk9AikKEettW/9s/tbSFDTpXcRbF+u1aLrhHxDFaYtZpFQ==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.16.0.tgz",
+      "integrity": "sha512-D1PNcdT0y4Grhou5Zi/qgipZOYeWrhLEpk33n3nm6LGtz61jvO88WlrWCK/bigMjpnOdAUKKQwsGIl0NtWMyYw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.9",
@@ -3695,14 +3797,14 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.13.2",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.13.2.tgz",
-      "integrity": "sha512-riCBqZmNkYBWjXpM3qWLDQw7QmTKsVZDPhLXFJqC87+OjocEVpvS3dA2BPPUiLAu+m0/QmEj5pSXKhH+/DgerQ==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.15.0.tgz",
+      "integrity": "sha512-WFKsY1q12ScGabnZWUB9c/QzZmz/ESorrV27OembB7Gz6rrh9m3GA4Srsv1uvW1s9AHO5DeZ6DdUTyF9zyNERQ==",
       "license": "MIT",
       "dependencies": {
         "bson": "^6.10.3",
         "kareem": "2.6.3",
-        "mongodb": "~6.15.0",
+        "mongodb": "~6.16.0",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
@@ -4775,9 +4877,9 @@
       }
     },
     "node_modules/tr46": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.0.tgz",
-      "integrity": "sha512-IUWnUK7ADYR5Sl1fZlO1INDUhVhatWl7BtJWsIhwJ0UAK7ilzzIa8uIqOO/aYVWHZPJkKbEL+362wrzoeRF7bw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"

--- a/package.json
+++ b/package.json
@@ -22,25 +22,25 @@
   },
   "homepage": "https://github.com/rubentalstra/librechat-prom-exporter#readme",
   "dependencies": {
-    "@librechat/data-schemas": "^0.0.6",
+    "@librechat/data-schemas": "^0.0.7",
     "librechat-data-provider": "^0.7.6998",
     "express": "^4.21.2",
-    "mongoose": "^8.13.2",
+    "mongoose": "^8.15.0",
     "prom-client": "^15.1.3"
   },
   "devDependencies": {
-    "@eslint/compat": "^1.2.8",
+    "@eslint/compat": "^1.2.9",
     "@eslint/eslintrc": "^3.3.1",
-    "@eslint/js": "^9.24.0",
+    "@eslint/js": "^9.27.0",
     "@microsoft/eslint-formatter-sarif": "^3.1.0",
-    "@types/express": "^4.17.21",
+    "@types/express": "^4.17.22",
     "@types/node": "^22.15.21",
     "@typescript-eslint/eslint-plugin": "^8.32.1",
     "@typescript-eslint/parser": "^8.32.1",
-    "eslint": "^9.24.0",
+    "eslint": "^9.27.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-jest": "^28.11.0",
-    "globals": "^16.0.0",
+    "globals": "^16.1.0",
     "typescript": "^5.8.3"
   }
 }


### PR DESCRIPTION
This pull request updates several dependencies in the `package.json` file to their latest versions, ensuring compatibility and potentially addressing bugs or vulnerabilities.

Dependency updates:

* Updated `@librechat/data-schemas` from `^0.0.6` to `^0.0.7`.
* Updated `mongoose` from `^8.13.2` to `^8.15.0`.

DevDependency updates:

* Updated `@eslint/compat` from `^1.2.8` to `^1.2.9`.
* Updated `@eslint/js` from `^9.24.0` to `^9.27.0`.
* Updated `@types/express` from `^4.17.21` to `^4.17.22`.
* Updated `eslint` from `^9.24.0` to `^9.27.0`.
* Updated `globals` from `^16.0.0` to `^16.1.0`.