### PR TITLE
Bump version to 0.3.1 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librechat-prom-exporter",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librechat-prom-exporter",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "ISC",
       "dependencies": {
         "@librechat/data-schemas": "^0.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-prom-exporter",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Prometheus exporter for LibreChat metrics",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This pull request includes a version bump for the `librechat-prom-exporter` package in the `package.json` file. The version has been updated from `0.3.0` to `0.3.1`, indicating a minor update.