### PR TITLE
feat: add active user count by email domain to advanced metrics

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,72 @@
-node_modules
-dist
-.git
+# Dependency directories
+node_modules/
+npm-debug.log*
+
+# Build output
+dist/
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage/
+*.lcov
+
+# Logs
+logs
+*.log
+
+# Diagnostic reports
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Git
+.git/
 .gitignore
+
+# Documentation
+README.md
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+SECURITY.md
+LICENSE
+
+# Docker files
 Dockerfile*
-docker-compose.yml
+docker-compose*
+
+# Assets (not needed in production)
+assets/
+
+# Configuration files that aren't needed in production
+eslint.config.mjs
+
+# Prometheus config (for development/example)
+prometheus.yml
+
+# JSON dashboard (for development/example)
+librechat-exporter-dashboard.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librechat-prom-exporter",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librechat-prom-exporter",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@librechat/data-schemas": "^0.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-prom-exporter",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Prometheus exporter for LibreChat metrics",
   "main": "dist/index.js",
   "scripts": {

--- a/src/metrics/advancedMetrics.ts
+++ b/src/metrics/advancedMetrics.ts
@@ -284,7 +284,7 @@ export async function updateAdvancedMetrics(): Promise<void> {
             },
             { $unwind: '$userDetails' },
             { $project: { emailDomain: { $arrayElemAt: [{ $split: ['$userDetails.email', '@'] }, 1] } } },
-            { $group: { _id: '$emailDomain',activeUserCount: { $sum: 1 } } },
+            { $group: { _id: '$emailDomain', activeUserCount: { $sum: 1 } } },
             { $project: {
                     _id: 0,
                     domain: '$_id',

--- a/src/metrics/advancedMetrics.ts
+++ b/src/metrics/advancedMetrics.ts
@@ -272,7 +272,7 @@ export async function updateAdvancedMetrics(): Promise<void> {
         // --- Active Users in Last 5 Minutes by Domain ---
 
         const activeUsersByDomainAgg = await Message.aggregate([
-            { $match: { createdAt: { $gte: fiveMinutesAgo } } } ,
+            { $match: { createdAt: { $gte: fiveMinutesAgo } } },
             { $group: { _id: '$user' } },
             { $addFields: { userId: { $toObjectId: '$_id' } } },
             { $lookup: {

--- a/src/metrics/advancedMetrics.ts
+++ b/src/metrics/advancedMetrics.ts
@@ -63,6 +63,11 @@ export const advancedGauges = {
         name: 'librechat_active_users',
         help: 'Number of active users within the last 5 minutes',
     }),
+    activeUserCountByDomain: new client.Gauge({
+        name: 'librechat_active_users_by_email_domain',
+        help: 'Number of active users within the last 5 minutes grouped by email domain',
+        labelNames: ['email_domain'],
+    }),
 
     userCountByDomain: new client.Gauge({
         name: 'librechat_user_count_by_email_domain',
@@ -263,6 +268,34 @@ export async function updateAdvancedMetrics(): Promise<void> {
         const activeUsers: number =
             activeUserAgg.length > 0 ? activeUserAgg[0].activeUsers : 0;
         advancedGauges.activeUserCount.set(activeUsers);
+
+        // --- Active Users in Last 5 Minutes by Domain ---
+
+        const activeUsersByDomainAgg = await Message.aggregate([
+            { $match: { createdAt: { $gte: fiveMinutesAgo } } } ,
+            { $group: { _id: '$user' } },
+            { $addFields: { userId: { $toObjectId: '$_id' } } },
+            { $lookup: {
+                    from: 'users',
+                    localField: 'userId',
+                    foreignField: '_id',
+                    as: 'userDetails',
+                },
+            },
+            { $unwind: '$userDetails' },
+            { $project: { emailDomain: { $arrayElemAt: [{ $split: ['$userDetails.email', '@'] }, 1] } } },
+            { $group: { _id: '$emailDomain',activeUserCount: { $sum: 1 } } },
+            { $project: {
+                    _id: 0,
+                    domain: '$_id',
+                    count: '$activeUserCount',
+                },
+            }]);
+
+        advancedGauges.activeUserCountByDomain.reset();
+        for (const result of activeUsersByDomainAgg) {
+            advancedGauges.activeUserCountByDomain.set({ email_domain: result.domain }, result.count);
+        }
 
         // --- Unique Users ---
         const uniqueUsers = await Message.distinct('user');


### PR DESCRIPTION
# Pull Request

## Description

This PR intends to add the active user count by e-mail domain. After the last contribution we think that also having the domain metrics by time basis would be good.

So we've made a new metric for that purpose

<img width="992" height="318" alt="image" src="https://github.com/user-attachments/assets/876770de-0abd-4056-b0ee-88a5afebce8f" />

I've went ahead and hide the domains, but as this is our test environment and it's weekend i'm the only one using it

Also, while at it I felt like tweaking a bit the dockerfiles to reduce the size of it. Arm based was taking 375MB and I felt like it was a little bit.

### Docker Image Size Reduction

| Architecture | Old Image | Old Size | New Image | New Size | Reduction (%) |
|---|---|---|---|---|---|
| `arm` | `prom-exporter:arm` | 375MB | `prom-exporter:distroless-arm` | 230MB | ~38.7% |
| `amd64` | `prom-exporter:amd64` | 75.3MB | `prom-exporter:distroless-amd64` | 58.1MB | ~22.8% |

I've this new image deployed and currently working on our k8s cluster (the first print was actually taken with it) so It should be working the same :)

## Checklist

- [x] My code follows the coding style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes do not produce any new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.

## Additional Notes

Add any additional notes or context here.
