### PR TITLE
feat: add unique user metrics by email domain for 7 and 30 days

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librechat-prom-exporter",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librechat-prom-exporter",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@librechat/data-schemas": "^0.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-prom-exporter",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Prometheus exporter for LibreChat metrics",
   "main": "dist/index.js",
   "scripts": {

--- a/src/metrics/advancedMetrics.ts
+++ b/src/metrics/advancedMetrics.ts
@@ -88,6 +88,16 @@ export const advancedGauges = {
         name: 'librechat_unique_users_count_30d',
         help: 'Unique users (last 30 days)',
     }),
+    uniqueUserCount7dByDomain: new client.Gauge({
+        name: 'librechat_unique_users_count_7d_by_email_domain',
+        help: 'Unique users (last 7 days) grouped by email domain',
+        labelNames: ['email_domain'],
+    }),
+    uniqueUserCount30dByDomain: new client.Gauge({
+        name: 'librechat_unique_users_count_30d_by_email_domain',
+        help: 'Unique users (last 30 days) grouped by email domain',
+        labelNames: ['email_domain'],
+    }),
 
     // Session metrics
     sessionAvgDuration: new client.Gauge({
@@ -269,34 +279,6 @@ export async function updateAdvancedMetrics(): Promise<void> {
             activeUserAgg.length > 0 ? activeUserAgg[0].activeUsers : 0;
         advancedGauges.activeUserCount.set(activeUsers);
 
-        // --- Active Users in Last 5 Minutes by Domain ---
-
-        const activeUsersByDomainAgg = await Message.aggregate([
-            { $match: { createdAt: { $gte: fiveMinutesAgo } } },
-            { $group: { _id: '$user' } },
-            { $addFields: { userId: { $toObjectId: '$_id' } } },
-            { $lookup: {
-                    from: 'users',
-                    localField: 'userId',
-                    foreignField: '_id',
-                    as: 'userDetails',
-                },
-            },
-            { $unwind: '$userDetails' },
-            { $project: { emailDomain: { $arrayElemAt: [{ $split: ['$userDetails.email', '@'] }, 1] } } },
-            { $group: { _id: '$emailDomain', activeUserCount: { $sum: 1 } } },
-            { $project: {
-                    _id: 0,
-                    domain: '$_id',
-                    count: '$activeUserCount',
-                },
-            }]);
-
-        advancedGauges.activeUserCountByDomain.reset();
-        for (const result of activeUsersByDomainAgg) {
-            advancedGauges.activeUserCountByDomain.set({ email_domain: result.domain }, result.count);
-        }
-
         // --- Unique Users ---
         const uniqueUsers = await Message.distinct('user');
         advancedGauges.uniqueUserCount.set(uniqueUsers.length);
@@ -315,6 +297,102 @@ export async function updateAdvancedMetrics(): Promise<void> {
 
         advancedGauges.uniqueUserCount7d.set(uniqueUsers7d.length);
         advancedGauges.uniqueUserCount30d.set(uniqueUsers30d.length);
+
+        // --- Combined Active/Unique Users by Email Domain (5min, 7d, 30d) ---
+        const usersByDomainResults = await Message.aggregate([
+            {
+                $facet: {
+                    // Active users in last 5 minutes by domain
+                    active5min: [
+                        { $match: { createdAt: { $gte: fiveMinutesAgo } } },
+                        { $group: { _id: '$user' } },
+                        { $addFields: { userId: { $toObjectId: '$_id' } } },
+                        { $lookup: {
+                                from: 'users',
+                                localField: 'userId',
+                                foreignField: '_id',
+                                as: 'userDetails',
+                            },
+                        },
+                        { $unwind: '$userDetails' },
+                        { $project: { emailDomain: { $arrayElemAt: [{ $split: ['$userDetails.email', '@'] }, 1] } } },
+                        { $group: { _id: '$emailDomain', userCount: { $sum: 1 } } },
+                        { $project: {
+                                _id: 0,
+                                domain: '$_id',
+                                count: '$userCount',
+                            },
+                        },
+                    ],
+                    // Unique users in last 7 days by domain
+                    unique7d: [
+                        { $match: { createdAt: { $gte: sevenDaysAgo } } },
+                        { $group: { _id: '$user' } },
+                        { $addFields: { userId: { $toObjectId: '$_id' } } },
+                        { $lookup: {
+                                from: 'users',
+                                localField: 'userId',
+                                foreignField: '_id',
+                                as: 'userDetails',
+                            },
+                        },
+                        { $unwind: '$userDetails' },
+                        { $project: { emailDomain: { $arrayElemAt: [{ $split: ['$userDetails.email', '@'] }, 1] } } },
+                        { $group: { _id: '$emailDomain', userCount: { $sum: 1 } } },
+                        { $project: {
+                                _id: 0,
+                                domain: '$_id',
+                                count: '$userCount',
+                            },
+                        },
+                    ],
+                    // Unique users in last 30 days by domain
+                    unique30d: [
+                        { $match: { createdAt: { $gte: thirtyDaysAgo } } },
+                        { $group: { _id: '$user' } },
+                        { $addFields: { userId: { $toObjectId: '$_id' } } },
+                        { $lookup: {
+                                from: 'users',
+                                localField: 'userId',
+                                foreignField: '_id',
+                                as: 'userDetails',
+                            },
+                        },
+                        { $unwind: '$userDetails' },
+                        { $project: { emailDomain: { $arrayElemAt: [{ $split: ['$userDetails.email', '@'] }, 1] } } },
+                        { $group: { _id: '$emailDomain', userCount: { $sum: 1 } } },
+                        { $project: {
+                                _id: 0,
+                                domain: '$_id',
+                                count: '$userCount',
+                            },
+                        },
+                    ],
+                },
+            },
+        ]);
+
+        // Process results and set metrics
+        const [activeUsersByDomainAgg, uniqueUsers7dByDomainAgg, uniqueUsers30dByDomainAgg] = [
+            usersByDomainResults[0]?.active5min || [],
+            usersByDomainResults[0]?.unique7d || [],
+            usersByDomainResults[0]?.unique30d || [],
+        ];
+
+        advancedGauges.activeUserCountByDomain.reset();
+        for (const result of activeUsersByDomainAgg) {
+            advancedGauges.activeUserCountByDomain.set({ email_domain: result.domain }, result.count);
+        }
+
+        advancedGauges.uniqueUserCount7dByDomain.reset();
+        for (const result of uniqueUsers7dByDomainAgg) {
+            advancedGauges.uniqueUserCount7dByDomain.set({ email_domain: result.domain }, result.count);
+        }
+
+        advancedGauges.uniqueUserCount30dByDomain.reset();
+        for (const result of uniqueUsers30dByDomainAgg) {
+            advancedGauges.uniqueUserCount30dByDomain.set({ email_domain: result.domain }, result.count);
+        }
 
         // --- Session Metrics ---
         const sessionAgg = await Session.aggregate([


### PR DESCRIPTION
# Pull Request

This pull request enhances the user metrics system by adding new gauges and aggregations for unique users, specifically grouped by email domain and over different time windows. The changes improve the granularity of user analytics and streamline the aggregation logic for better maintainability.

**Metrics enhancements:**

* Added two new gauges, `uniqueUserCount7dByDomain` and `uniqueUserCount30dByDomain`, to track the number of unique users in the last 7 and 30 days, grouped by email domain.
* Implemented logic to populate these new metrics by aggregating unique users by domain for the specified time windows.

**Aggregation and code organization improvements:**

* Refactored the aggregation logic to use a single `$facet` pipeline, efficiently collecting active users (last 5 minutes) and unique users (last 7 and 30 days) by email domain in one query. [[1]](diffhunk://#diff-766c5b7c9b8321533fffd3acde84eed89b0bd135bf3178547ef23a85cd473c06L272-R306) [[2]](diffhunk://#diff-766c5b7c9b8321533fffd3acde84eed89b0bd135bf3178547ef23a85cd473c06L287-R395)
* Updated the process for setting Prometheus gauges to handle the new domain-grouped unique user metrics, including proper resets and updates for each domain.

## Description

This PR intends to also add Unique Users Rolling Window for 7d and 30d.
While at it, i've leveraged $facet to improve performance on 3 metrics, this 2 new and the 5min active users.

<img width="1472" height="463" alt="image" src="https://github.com/user-attachments/assets/eef50e1f-bd4f-4512-90c7-666c718fadcd" />

As normal, we've tested this image by deploying to our cluster and checking Grafana :) 

## Checklist

- [x] My code follows the coding style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes do not produce any new warnings.
