### PR TITLE
Adds new metrics and put all the metrics with the same timestamp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-prom-exporter",
-  "version": "0.4.2",
+  "version": "0.4.4",
   "description": "Prometheus exporter for LibreChat metrics",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This pull request adds new metrics for tracking unique users over a 1-day window, both globally and grouped by email domain, and refactors the advanced metrics logic to support these new time windows. It also bumps the package version to 0.4.4. The main changes are grouped below:

**Metrics Additions:**

* Added `uniqueUserCount1d` and `uniqueUserCount1dByDomain` gauges in `advancedGauges` to track unique users in the last 1 day, both globally and by email domain. [[1]](diffhunk://#diff-766c5b7c9b8321533fffd3acde84eed89b0bd135bf3178547ef23a85cd473c06R95-R98) [[2]](diffhunk://#diff-766c5b7c9b8321533fffd3acde84eed89b0bd135bf3178547ef23a85cd473c06R107-R111)
* Updated the advanced metrics update logic to calculate and set values for the new 1-day unique user metrics. [[1]](diffhunk://#diff-766c5b7c9b8321533fffd3acde84eed89b0bd135bf3178547ef23a85cd473c06L368-R403) [[2]](diffhunk://#diff-766c5b7c9b8321533fffd3acde84eed89b0bd135bf3178547ef23a85cd473c06R425-R429)

**Refactoring and Pipeline Updates:**

* Refactored time window calculations to use a single `now` reference and added a 1-day window alongside existing 7-day and 30-day windows. [[1]](diffhunk://#diff-766c5b7c9b8321533fffd3acde84eed89b0bd135bf3178547ef23a85cd473c06R250-R255) [[2]](diffhunk://#diff-766c5b7c9b8321533fffd3acde84eed89b0bd135bf3178547ef23a85cd473c06L308) [[3]](diffhunk://#diff-766c5b7c9b8321533fffd3acde84eed89b0bd135bf3178547ef23a85cd473c06L354)
* Updated the aggregation pipeline and metric processing to include the new 1-day window for users by domain. [[1]](diffhunk://#diff-766c5b7c9b8321533fffd3acde84eed89b0bd135bf3178547ef23a85cd473c06L368-R403) [[2]](diffhunk://#diff-766c5b7c9b8321533fffd3acde84eed89b0bd135bf3178547ef23a85cd473c06L398-R415)

**Version Update:**

* Bumped the package version from 0.4.2 to 0.4.4 in `package.json`.
