### PR TITLE
feat: enhance HTTP server security with rate limiting and authentication options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,7 +40,73 @@ EMIT_PER_USER_METRICS=false
 # prepend a `{ $match: { tenantId } }` stage to every aggregate, and
 # merge `{ tenantId }` into every find/count query, so per-metric
 # values reflect only the named tenant.
-# Caveat: Conversation total uses estimatedDocumentCount() which is
-# tenant-blind by design (no filter support); all other metrics scope
-# correctly.
 # TENANT_ID=your-tenant-id
+
+# ---------------------------------------------------------------------------
+# HTTP server, security, auth
+# ---------------------------------------------------------------------------
+
+# Optional second port for /metrics only. When set and different from PORT,
+# the exporter binds a second HTTP server on this port that hosts /metrics.
+# /health stays on PORT. Matches the "separate internal metrics server"
+# pattern: expose only the smaller surface externally if needed.
+# METRICS_PORT=9088
+
+# Value passed to Express `app.set('trust proxy', ...)`. Default 'loopback'.
+# Set to 'true' behind a single trusted reverse proxy, or a CIDR list (e.g.
+# '10.0.0.0/8, 172.16.0.0/12') so req.ip / IP allowlist reflect the real
+# client instead of the proxy.
+# TRUST_PROXY=loopback
+
+# Per-IP rate limit on /metrics. Window in ms and max requests per window.
+# Default: 120 requests per 60s.
+# RATE_LIMIT_WINDOW_MS=60000
+# RATE_LIMIT_MAX=120
+
+# Per-IP rate limit on /health. Default 600 per 60s window.
+# HEALTH_RATE_LIMIT_MAX=600
+
+# ---- Auth on /metrics ----
+# All four methods are OFF by default. /metrics is publicly accessible
+# unless at least one method below is configured. Multiple methods may be
+# combined: any token method authorizes; the IP allowlist (if set) is
+# enforced in addition to whichever token method matches.
+
+# (1) Static bearer token. Simplest method.
+# Requires `Authorization: Bearer <token>` on the request.
+# Matches Prometheus `authorization:` block / Alloy `authorization {}`.
+# METRICS_BEARER_TOKEN=
+
+# (2) HTTP Basic. Both vars must be set together.
+# Matches Prometheus / Alloy `basic_auth:` block.
+# METRICS_BASIC_AUTH_USER=
+# METRICS_BASIC_AUTH_PASSWORD=
+
+# (3) OAuth2 / OIDC JWT validation.
+# The exporter validates incoming Bearer tokens against an IdP's JWKS.
+# Prometheus / Alloy run the OAuth2 client_credentials grant against the
+# IdP themselves (see `oauth2:` block in scrape config) and forward the
+# resulting access token.
+#
+# Required: METRICS_OAUTH2_AUDIENCE, plus EITHER
+#   - METRICS_OAUTH2_JWKS_URI (the issuer's JWKS endpoint), OR
+#   - METRICS_OAUTH2_ISSUER  (the issuer URL; the exporter discovers JWKS
+#                            from /.well-known/openid-configuration at boot)
+# Optional: METRICS_OAUTH2_REQUIRED_SCOPES (space-separated; token must
+#           carry all of them in `scope` or `scp`)
+# Optional: METRICS_OAUTH2_ALGORITHMS (comma-separated; default 'RS256,ES256')
+#
+# METRICS_OAUTH2_ISSUER=https://idp.example.com/realms/main
+# METRICS_OAUTH2_JWKS_URI=
+# METRICS_OAUTH2_AUDIENCE=librechat-prom-exporter
+# METRICS_OAUTH2_REQUIRED_SCOPES=metrics:read
+# METRICS_OAUTH2_ALGORITHMS=RS256,ES256
+
+# (4) IP allowlist. Comma-separated CIDRs (IPv4 or IPv6). Requests whose
+# req.ip does not match any range are rejected with 403. When combined
+# with a token method, both must pass.
+# METRICS_ALLOWED_IPS=10.0.0.0/8, 172.16.0.0/12
+
+# Log auth rejections at warn level (rate-limited to ~1/sec to prevent
+# log floods under attack). Default true. Set to false to silence.
+# METRICS_AUTH_LOG_REJECTS=true

--- a/README.md
+++ b/README.md
@@ -94,16 +94,31 @@ This setup uses the prebuilt **LibreChat Prometheus Exporter** image from GitHub
 
 The following environment variables can be configured via the `.env` file (or your shell environment). Use the provided `.env.example` as a starting point.
 
-| Variable                    | Default                                          | Description                                                                                                                                                                                                                                                    |
-|-----------------------------|--------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `MONGO_URI`                 | `mongodb://host.docker.internal:27017/librechat` | The connection string for your LibreChat MongoDB database.                                                                                                                                                                                                     |
-| `PORT`                      | `9087`                                           | The port on which the exporter will run and expose `/metrics`.                                                                                                                                                                                                 |
-| `REFRESH_INTERVAL`          | `30000`                                          | Interval in ms for the basic metrics scrape (cheap, runs often).                                                                                                                                                                                               |
-| `ADVANCED_REFRESH_INTERVAL` | `REFRESH_INTERVAL × 10`                          | Interval in ms for the advanced metrics scrape (heavy, runs separately so a slow advanced cycle doesn't block basic).                                                                                                                                          |
-| `MONGO_POOL_SIZE`           | `50`                                             | `maxPoolSize` passed to `mongoose.connect`.                                                                                                                                                                                                                    |
-| `LOG_TIMINGS`               | `false`                                          | When `true`, prints per-scrape and per-section timing lines to stdout. Per-section durations are also exposed as the `librechat_exporter_section_duration_seconds` histogram regardless of this flag. Accepts `true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`. |
-| `EMIT_PER_USER_METRICS`     | `false`                                          | When `true`, emits the three high-cardinality `email`-labeled metrics (see [Cardinality](#cardinality) below). Default off to protect large deployments.                                                                                                       |
-| `TENANT_ID`                 | _(unset)_                                        | When set, installs mongoose schema hooks that scope every aggregate / find / count query to the named tenant. Leave unset on single-tenant LibreChat installs (the default).                                                                                   |
+| Variable                         | Default                                          | Description                                                                                                                                                                                                                                                    |
+|----------------------------------|--------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `MONGO_URI`                      | `mongodb://host.docker.internal:27017/librechat` | The connection string for your LibreChat MongoDB database.                                                                                                                                                                                                     |
+| `PORT`                           | `9087`                                           | The port on which the exporter will run and expose `/metrics`.                                                                                                                                                                                                 |
+| `REFRESH_INTERVAL`               | `30000`                                          | Interval in ms for the basic metrics scrape (cheap, runs often).                                                                                                                                                                                               |
+| `ADVANCED_REFRESH_INTERVAL`      | `REFRESH_INTERVAL × 10`                          | Interval in ms for the advanced metrics scrape (heavy, runs separately so a slow advanced cycle doesn't block basic).                                                                                                                                          |
+| `MONGO_POOL_SIZE`                | `50`                                             | `maxPoolSize` passed to `mongoose.connect`.                                                                                                                                                                                                                    |
+| `LOG_TIMINGS`                    | `false`                                          | When `true`, prints per-scrape and per-section timing lines to stdout. Per-section durations are also exposed as the `librechat_exporter_section_duration_seconds` histogram regardless of this flag. Accepts `true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`. |
+| `EMIT_PER_USER_METRICS`          | `false`                                          | When `true`, emits the three high-cardinality `email`-labeled metrics (see [Cardinality](#cardinality) below). Default off to protect large deployments.                                                                                                       |
+| `TENANT_ID`                      | _(unset)_                                        | When set, installs mongoose schema hooks that scope every aggregate / find / count query to the named tenant. Leave unset on single-tenant LibreChat installs (the default).                                                                                   |
+| `METRICS_PORT`                   | _(unset)_                                        | Optional second port for `/metrics` only. If set and different from `PORT`, `/metrics` binds there and `/health` stays on `PORT`. Useful for k8s sidecar / internal-only metrics scraping.                                                                     |
+| `TRUST_PROXY`                    | `loopback`                                       | Value passed to `app.set('trust proxy', ...)`. Set when running behind a reverse proxy so `req.ip` / IP allowlist see real clients. Accepts `true`, `false`, CIDR list, or `loopback`/`linklocal`/`uniquelocal`.                                               |
+| `RATE_LIMIT_WINDOW_MS`           | `60000`                                          | Per-IP rate limit window in ms.                                                                                                                                                                                                                                |
+| `RATE_LIMIT_MAX`                 | `120`                                            | Max requests per IP to `/metrics` per window.                                                                                                                                                                                                                  |
+| `HEALTH_RATE_LIMIT_MAX`          | `600`                                            | Max requests per IP to `/health` per window.                                                                                                                                                                                                                   |
+| `METRICS_BEARER_TOKEN`           | _(unset)_                                        | If set, `/metrics` requires `Authorization: Bearer <token>`. See [Auth](#auth-on-metrics).                                                                                                                                                                     |
+| `METRICS_BASIC_AUTH_USER`        | _(unset)_                                        | HTTP Basic username. Must be set together with `METRICS_BASIC_AUTH_PASSWORD`.                                                                                                                                                                                  |
+| `METRICS_BASIC_AUTH_PASSWORD`    | _(unset)_                                        | HTTP Basic password.                                                                                                                                                                                                                                           |
+| `METRICS_OAUTH2_ISSUER`          | _(unset)_                                        | OIDC issuer URL. Exporter discovers JWKS from `${issuer}/.well-known/openid-configuration` at boot. Mutually exclusive with `METRICS_OAUTH2_JWKS_URI`.                                                                                                         |
+| `METRICS_OAUTH2_JWKS_URI`        | _(unset)_                                        | Direct JWKS endpoint URL. Use when the IdP does not expose OIDC discovery.                                                                                                                                                                                     |
+| `METRICS_OAUTH2_AUDIENCE`        | _(unset)_                                        | Required if any `METRICS_OAUTH2_*` is set. The `aud` claim the exporter accepts.                                                                                                                                                                               |
+| `METRICS_OAUTH2_REQUIRED_SCOPES` | _(unset)_                                        | Space-separated scopes. Token must carry every listed scope in `scope` or `scp`.                                                                                                                                                                               |
+| `METRICS_OAUTH2_ALGORITHMS`      | `RS256,ES256`                                    | Comma-separated allowed JWT signing algorithms.                                                                                                                                                                                                                |
+| `METRICS_ALLOWED_IPS`            | _(unset)_                                        | Comma-separated CIDRs (IPv4 / IPv6). Requests outside the list are rejected with 403. Combine with a token method (both must pass) or use standalone.                                                                                                          |
+| `METRICS_AUTH_LOG_REJECTS`       | `true`                                           | Log auth rejections (rate-limited to ~1/sec). Set to `false` to silence.                                                                                                                                                                                       |
 
 Example `.env` file (generated by copying `.env.example`):
 ```
@@ -121,6 +136,78 @@ Three metrics carry an `email` label and emit one Prometheus series per user. On
 - `librechat_agent_usage_by_user_count{agent,email}`
 
 The corresponding `*_by_email_domain` variants are bounded by company domains and remain enabled by default.
+
+### Auth on `/metrics`
+
+`/metrics` is **publicly accessible by default**. The exporter ships with four optional auth methods that can be enabled via environment variables. Any combination is supported; the IP allowlist (if set) is enforced in addition to whichever token method authorizes the request.
+
+| Method              | Enable with                                                            | Prometheus / Alloy scrape side                            |
+|---------------------|------------------------------------------------------------------------|-----------------------------------------------------------|
+| Static bearer token | `METRICS_BEARER_TOKEN`                                                 | `authorization: { type: Bearer, credentials: <token> }`   |
+| HTTP Basic          | `METRICS_BASIC_AUTH_USER` + `METRICS_BASIC_AUTH_PASSWORD`              | `basic_auth: { username, password }`                      |
+| OAuth2 / OIDC JWT   | `METRICS_OAUTH2_{ISSUER,JWKS_URI,AUDIENCE,REQUIRED_SCOPES,ALGORITHMS}` | `oauth2: { client_id, client_secret, token_url, scopes }` |
+| IP allowlist        | `METRICS_ALLOWED_IPS` (comma-separated CIDRs)                          | _(network-layer; no scrape-side config)_                  |
+
+**Which method should I pick?**
+
+- **Static bearer token** — simplest; one secret, no IdP needed. Fine for small deployments and CI scrapers.
+- **HTTP Basic** — compatible with older Prometheus setups that prefer `basic_auth`. Behavior is equivalent to static bearer.
+- **OAuth2 / OIDC** — best for enterprise setups with an IdP (Keycloak, Auth0, Okta, Azure AD). Tokens rotate, scopes are enforced, secrets never leave the IdP. The exporter validates the JWT against the issuer's JWKS (cached for 10 min, with automatic key rotation).
+- **IP allowlist** — defense in depth. Pair with a token method to require both network and credential checks, or use standalone when network isolation is your only requirement.
+
+If none of the four env vars is set, `/metrics` stays open (current behavior, no breaking change).
+
+**Prometheus scrape examples**
+
+Static bearer:
+
+```yaml
+scrape_configs:
+  - job_name: 'librechat-exporter'
+    authorization:
+      type: Bearer
+      credentials: "your-shared-secret"
+    static_configs:
+      - targets: ['exporter:9087']
+```
+
+Basic auth:
+
+```yaml
+scrape_configs:
+  - job_name: 'librechat-exporter'
+    basic_auth:
+      username: prom
+      password: "your-password"
+    static_configs:
+      - targets: ['exporter:9087']
+```
+
+OAuth2 (client_credentials against your IdP):
+
+```yaml
+scrape_configs:
+  - job_name: 'librechat-exporter'
+    oauth2:
+      client_id: "prometheus"
+      client_secret: "your-client-secret"
+      token_url: "https://idp.example.com/realms/main/protocol/openid-connect/token"
+      scopes: ["metrics:read"]
+    static_configs:
+      - targets: ['exporter:9087']
+```
+
+The exporter side is then configured with:
+
+```bash
+METRICS_OAUTH2_ISSUER=https://idp.example.com/realms/main
+METRICS_OAUTH2_AUDIENCE=librechat-prom-exporter
+METRICS_OAUTH2_REQUIRED_SCOPES=metrics:read
+```
+
+**Grafana Alloy** uses the same primitives in its `prometheus.scrape` component (`basic_auth`, `authorization`, `oauth2` blocks). See the [Alloy `prometheus.scrape` reference](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.scrape/) and the [Prometheus `scrape_config` reference](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config).
+
+When running behind a reverse proxy, also set `TRUST_PROXY=true` (or a CIDR list) so the IP allowlist and rate limiter see real client IPs instead of the proxy.
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,13 @@
       "license": "MIT",
       "dependencies": {
         "@librechat/data-schemas": "^0.0.51",
+        "compression": "^1.8.1",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.5.2",
+        "helmet": "^8.1.0",
+        "ipaddr.js": "^2.4.0",
+        "jose": "^6.2.3",
         "librechat-data-provider": "^0.8.502",
         "mongoose": "^8.24.0",
         "prom-client": "^15.1.3"
@@ -21,6 +26,7 @@
         "@eslint/eslintrc": "^3.3.5",
         "@eslint/js": "^9.39.4",
         "@microsoft/eslint-formatter-sarif": "^3.1.0",
+        "@types/compression": "^1.8.1",
         "@types/express": "^5.0.6",
         "@types/node": "^25.5.0",
         "@typescript-eslint/eslint-plugin": "^8.59.4",
@@ -1194,6 +1200,17 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@types/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-kCFuWS0ebDbmxs0AXYn6e2r2nrGAb5KwQhknjSPSPgJcGd8+HVSILlUyFhGqML2gk39HcG7D1ydW9/qpYkN00Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -2115,6 +2132,60 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3014,6 +3085,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -3577,6 +3666,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -3696,13 +3794,22 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4127,6 +4234,15 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4792,6 +4908,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5003,6 +5128,15 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,13 @@
   "homepage": "https://github.com/rubentalstra/librechat-prom-exporter#readme",
   "dependencies": {
     "@librechat/data-schemas": "^0.0.51",
+    "compression": "^1.8.1",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.5.2",
+    "helmet": "^8.1.0",
+    "ipaddr.js": "^2.4.0",
+    "jose": "^6.2.3",
     "librechat-data-provider": "^0.8.502",
     "mongoose": "^8.24.0",
     "prom-client": "^15.1.3"
@@ -34,6 +39,7 @@
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^9.39.4",
     "@microsoft/eslint-formatter-sarif": "^3.1.0",
+    "@types/compression": "^1.8.1",
     "@types/express": "^5.0.6",
     "@types/node": "^25.5.0",
     "@typescript-eslint/eslint-plugin": "^8.59.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,22 @@
-import express, { NextFunction, Request, Response } from "express";
+import compression from "compression";
+import "dotenv/config";
+import express, { NextFunction, Request, RequestHandler, Response } from "express";
+import rateLimit from "express-rate-limit";
+import helmet from "helmet";
 import mongoose from "mongoose";
 import client from "prom-client";
-import "dotenv/config";
-import { basicGauges } from "./metrics/basicMetrics.js";
+
 import { advancedGauges } from "./metrics/advancedMetrics.js";
+import { basicGauges } from "./metrics/basicMetrics.js";
 import {
-  updateBasicMetricsTimed,
   updateAdvancedMetricsTimed,
+  updateBasicMetricsTimed,
   waitForIdle,
 } from "./metrics/index.js";
-import { envFlag } from "./metrics/util.js";
 import { assertIndexes } from "./metrics/indexAssertions.js";
 import { installTenantHooks } from "./metrics/tenantHooks.js";
+import { envFlag } from "./metrics/util.js";
+import { buildMetricsAuth } from "./middleware/metricsAuth.js";
 
 const TENANT_ID = process.env.TENANT_ID;
 if (TENANT_ID) {
@@ -19,23 +24,28 @@ if (TENANT_ID) {
   console.log(`Tenant scoping active: tenantId=${TENANT_ID}`);
 }
 
-const app = express();
-const port = process.env.PORT || 3000;
-const refreshInterval = parseInt(process.env.REFRESH_INTERVAL || "30000");
+const port = parseInt(process.env.PORT || "3000", 10);
+const metricsPortEnv = process.env.METRICS_PORT;
+const metricsPort = metricsPortEnv ? parseInt(metricsPortEnv, 10) : undefined;
+const refreshInterval = parseInt(process.env.REFRESH_INTERVAL || "30000", 10);
 const advancedRefreshInterval = parseInt(
   process.env.ADVANCED_REFRESH_INTERVAL || String(refreshInterval * 10),
+  10,
+);
+const trustProxy = process.env.TRUST_PROXY || "loopback";
+const rateLimitWindowMs = parseInt(process.env.RATE_LIMIT_WINDOW_MS || "60000", 10);
+const rateLimitMax = parseInt(process.env.RATE_LIMIT_MAX || "120", 10);
+const healthRateLimitMax = parseInt(
+  process.env.HEALTH_RATE_LIMIT_MAX || "600",
+  10,
 );
 
-// Create a Prometheus registry and collect default metrics.
 const register = new client.Registry();
 client.collectDefaultMetrics({ register });
 
-// Register basic gauges.
 for (const gauge of Object.values(basicGauges)) {
   register.registerMetric(gauge);
 }
-
-// Register advanced gauges.
 for (const gauge of Object.values(advancedGauges)) {
   register.registerMetric(gauge as client.Metric);
 }
@@ -55,11 +65,10 @@ mongoose.connection.on("error", () =>
 );
 
 const mongoURI = process.env.MONGO_URI || "mongodb://localhost:27017/librechat";
-const mongoPoolSize = parseInt(process.env.MONGO_POOL_SIZE || "50");
+const mongoPoolSize = parseInt(process.env.MONGO_POOL_SIZE || "50", 10);
 mongoose
   .connect(mongoURI, {
     maxPoolSize: mongoPoolSize,
-    // 5s vs the mongoose default of 30s so /health flips fast on outage
     serverSelectionTimeoutMS: 5000,
   })
   .then(() => {
@@ -84,18 +93,38 @@ if (envFlag("LOG_TIMINGS", false)) {
 updateBasicMetricsTimed();
 updateAdvancedMetricsTimed();
 
-app.get("/metrics", async (_req: Request, res: Response) => {
-  res.set("Content-Type", register.contentType);
-  res.send(await register.metrics());
-});
-
 const READY_STATE_LABEL: Record<number, string> = {
   0: "disconnected",
   1: "connected",
   2: "connecting",
   3: "disconnecting",
 };
-app.get("/health", (_req: Request, res: Response) => {
+
+const helmetMiddleware = helmet({
+  contentSecurityPolicy: false,
+  crossOriginResourcePolicy: false,
+});
+
+function applyBaseMiddleware(target: express.Application): void {
+  target.set("trust proxy", trustProxy);
+  target.disable("x-powered-by");
+  target.use(helmetMiddleware);
+  target.use(compression());
+  target.use(express.json({ limit: "10kb" }));
+}
+
+const metricsHandler: RequestHandler = async (
+  _req: Request,
+  res: Response,
+): Promise<void> => {
+  res.set("Content-Type", register.contentType);
+  res.send(await register.metrics());
+};
+
+const healthHandler: RequestHandler = (
+  _req: Request,
+  res: Response,
+): void => {
   const state = mongoose.connection.readyState;
   if (state === 1) {
     res.status(200).json({ status: "ok", mongo: "connected" });
@@ -105,19 +134,75 @@ app.get("/health", (_req: Request, res: Response) => {
       mongo: READY_STATE_LABEL[state] ?? `unknown(${state})`,
     });
   }
+};
+
+const errorHandler = (
+  err: Error,
+  _req: Request,
+  res: Response,
+  _next: NextFunction,
+): void => {
+  console.error("Unhandled error:", err);
+  res.status(500).send("Internal Server Error");
+};
+
+const metricsLimiter = rateLimit({
+  windowMs: rateLimitWindowMs,
+  limit: rateLimitMax,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+});
+const healthLimiter = rateLimit({
+  windowMs: rateLimitWindowMs,
+  limit: healthRateLimitMax,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
 });
 
-// Express error middleware: must be last and must have 4 params.
-app.use(
-  (err: Error, _req: Request, res: Response, _next: NextFunction): void => {
-    console.error("Unhandled error:", err);
-    res.status(500).send("Internal Server Error");
-  },
-);
+const servers: import("http").Server[] = [];
 
-const server = app.listen(port, () => {
-  console.log(`Exporter listening on port ${port}`);
-});
+async function start(): Promise<void> {
+  let metricsAuth: RequestHandler;
+  try {
+    metricsAuth = await buildMetricsAuth();
+  } catch (err) {
+    console.error("[metrics-auth] configuration error:", err);
+    process.exit(1);
+  }
+
+  const primaryApp = express();
+  applyBaseMiddleware(primaryApp);
+  primaryApp.get("/health", healthLimiter, healthHandler);
+
+  if (metricsPort && metricsPort !== port) {
+    const metricsApp = express();
+    applyBaseMiddleware(metricsApp);
+    metricsApp.get("/metrics", metricsLimiter, metricsAuth, metricsHandler);
+    metricsApp.use(errorHandler);
+    primaryApp.use(errorHandler);
+
+    servers.push(
+      primaryApp.listen(port, () =>
+        console.log(`Health endpoint listening on port ${port}`),
+      ),
+    );
+    servers.push(
+      metricsApp.listen(metricsPort, () =>
+        console.log(`Metrics endpoint listening on port ${metricsPort}`),
+      ),
+    );
+  } else {
+    primaryApp.get("/metrics", metricsLimiter, metricsAuth, metricsHandler);
+    primaryApp.use(errorHandler);
+    servers.push(
+      primaryApp.listen(port, () =>
+        console.log(`Exporter listening on port ${port}`),
+      ),
+    );
+  }
+}
+
+start();
 
 let isShuttingDown = false;
 async function shutdown(signal: NodeJS.Signals): Promise<void> {
@@ -129,7 +214,11 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
   console.log(`[shutdown] received ${signal} — draining`);
   clearInterval(basicTimer);
   clearInterval(advancedTimer);
-  await new Promise<void>((resolve) => server.close(() => resolve()));
+  await Promise.all(
+    servers.map(
+      (s) => new Promise<void>((resolve) => s.close(() => resolve())),
+    ),
+  );
   await waitForIdle();
   try {
     await mongoose.disconnect();

--- a/src/middleware/metricsAuth.ts
+++ b/src/middleware/metricsAuth.ts
@@ -1,0 +1,319 @@
+import { timingSafeEqual } from "crypto";
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+import {
+  createRemoteJWKSet,
+  errors as joseErrors,
+  jwtVerify,
+  type JWTPayload,
+  type JWTVerifyGetKey,
+} from "jose";
+import ipaddr from "ipaddr.js";
+
+import { envFlag } from "../metrics/util.js";
+
+interface OAuth2Config {
+  jwksUri: string;
+  issuer?: string;
+  audience: string;
+  requiredScopes: string[];
+  algorithms: string[];
+}
+
+interface ResolvedConfig {
+  bearerToken?: string;
+  basicHeader?: string;
+  oauth2?: OAuth2Config;
+  cidrs?: Array<[ipaddr.IPv4 | ipaddr.IPv6, number]>;
+  enabled: boolean;
+}
+
+function splitCsv(value: string | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function splitScopes(value: string | undefined): string[] {
+  if (!value) {
+    return [];
+  }
+  return value
+    .split(/\s+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function parseCidrs(
+  csv: string | undefined,
+): Array<[ipaddr.IPv4 | ipaddr.IPv6, number]> | undefined {
+  const items = splitCsv(csv);
+  if (items.length === 0) {
+    return undefined;
+  }
+  return items.map((cidr) => {
+    try {
+      return ipaddr.parseCIDR(cidr);
+    } catch {
+      const addr = ipaddr.parse(cidr);
+      const bits = addr.kind() === "ipv4" ? 32 : 128;
+      return [addr, bits] as [ipaddr.IPv4 | ipaddr.IPv6, number];
+    }
+  });
+}
+
+function buildBasicHeader(user: string, password: string): string {
+  return "Basic " + Buffer.from(`${user}:${password}`).toString("base64");
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) {
+    return false;
+  }
+  return timingSafeEqual(ab, bb);
+}
+
+async function discoverJwksUri(issuer: string): Promise<string> {
+  const url = issuer.replace(/\/$/, "") + "/.well-known/openid-configuration";
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(
+      `OIDC discovery failed: GET ${url} -> ${res.status} ${res.statusText}`,
+    );
+  }
+  const body = (await res.json()) as { jwks_uri?: string };
+  if (!body.jwks_uri || typeof body.jwks_uri !== "string") {
+    throw new Error(`OIDC discovery response missing jwks_uri: ${url}`);
+  }
+  return body.jwks_uri;
+}
+
+function clientIp(req: Request): string | null {
+  const ip = req.ip;
+  if (!ip) {
+    return null;
+  }
+  return ip.replace(/^::ffff:/, "");
+}
+
+function ipMatches(
+  ip: string,
+  cidrs: Array<[ipaddr.IPv4 | ipaddr.IPv6, number]>,
+): boolean {
+  let addr: ipaddr.IPv4 | ipaddr.IPv6;
+  try {
+    addr = ipaddr.parse(ip);
+  } catch {
+    return false;
+  }
+  for (const cidr of cidrs) {
+    if (addr.kind() !== cidr[0].kind()) {
+      continue;
+    }
+    try {
+      if (addr.match(cidr)) {
+        return true;
+      }
+    } catch {
+      // skip
+    }
+  }
+  return false;
+}
+
+function extractScopes(payload: JWTPayload): string[] {
+  const scope = (payload as Record<string, unknown>).scope;
+  if (typeof scope === "string") {
+    return splitScopes(scope);
+  }
+  const scp = (payload as Record<string, unknown>).scp;
+  if (Array.isArray(scp)) {
+    return scp.filter((s): s is string => typeof s === "string");
+  }
+  if (typeof scp === "string") {
+    return splitScopes(scp);
+  }
+  return [];
+}
+
+export async function buildMetricsAuth(): Promise<RequestHandler> {
+  const bearerToken = process.env.METRICS_BEARER_TOKEN || undefined;
+
+  const basicUser = process.env.METRICS_BASIC_AUTH_USER;
+  const basicPassword = process.env.METRICS_BASIC_AUTH_PASSWORD;
+  if ((basicUser && !basicPassword) || (!basicUser && basicPassword)) {
+    throw new Error(
+      "METRICS_BASIC_AUTH_USER and METRICS_BASIC_AUTH_PASSWORD must both be set or both unset",
+    );
+  }
+  const basicHeader =
+    basicUser && basicPassword ? buildBasicHeader(basicUser, basicPassword) : undefined;
+
+  let oauth2: OAuth2Config | undefined;
+  let jwks: JWTVerifyGetKey | undefined;
+  const audience = process.env.METRICS_OAUTH2_AUDIENCE;
+  const issuer = process.env.METRICS_OAUTH2_ISSUER;
+  let jwksUri = process.env.METRICS_OAUTH2_JWKS_URI;
+
+  const anyOauthEnv = audience || issuer || jwksUri ||
+    process.env.METRICS_OAUTH2_REQUIRED_SCOPES ||
+    process.env.METRICS_OAUTH2_ALGORITHMS;
+
+  if (anyOauthEnv) {
+    if (!audience) {
+      throw new Error("METRICS_OAUTH2_AUDIENCE is required when any METRICS_OAUTH2_* is set");
+    }
+    if (!jwksUri && !issuer) {
+      throw new Error("One of METRICS_OAUTH2_JWKS_URI or METRICS_OAUTH2_ISSUER must be set");
+    }
+    if (jwksUri && issuer) {
+      throw new Error("METRICS_OAUTH2_JWKS_URI and METRICS_OAUTH2_ISSUER are mutually exclusive");
+    }
+    if (!jwksUri && issuer) {
+      jwksUri = await discoverJwksUri(issuer);
+    }
+    oauth2 = {
+      jwksUri: jwksUri!,
+      issuer,
+      audience,
+      requiredScopes: splitScopes(process.env.METRICS_OAUTH2_REQUIRED_SCOPES),
+      algorithms: splitCsv(process.env.METRICS_OAUTH2_ALGORITHMS).length > 0
+        ? splitCsv(process.env.METRICS_OAUTH2_ALGORITHMS)
+        : ["RS256", "ES256"],
+    };
+    jwks = createRemoteJWKSet(new URL(oauth2.jwksUri), {
+      cacheMaxAge: 10 * 60 * 1000,
+      cooldownDuration: 30 * 1000,
+    });
+  }
+
+  const cidrs = parseCidrs(process.env.METRICS_ALLOWED_IPS);
+
+  const config: ResolvedConfig = {
+    bearerToken,
+    basicHeader,
+    oauth2,
+    cidrs,
+    enabled: Boolean(bearerToken || basicHeader || oauth2 || cidrs),
+  };
+
+  const hasTokenMethod = Boolean(bearerToken || basicHeader || oauth2);
+  const logRejects = envFlag("METRICS_AUTH_LOG_REJECTS", true);
+  let lastLogAt = 0;
+  const logReject = (req: Request, reason: string): void => {
+    if (!logRejects) {
+      return;
+    }
+    const now = Date.now();
+    if (now - lastLogAt < 1000) {
+      return;
+    }
+    lastLogAt = now;
+    console.warn(
+      `[metrics-auth] reject ${req.method} ${req.path} from ${clientIp(req) ?? "?"}: ${reason}`,
+    );
+  };
+
+  return async function metricsAuth(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    if (!config.enabled) {
+      next();
+      return;
+    }
+
+    if (config.cidrs) {
+      const ip = clientIp(req);
+      if (!ip || !ipMatches(ip, config.cidrs)) {
+        logReject(req, "ip not in allowlist");
+        if (!hasTokenMethod) {
+          res.status(403).type("text/plain").send("Forbidden");
+          return;
+        }
+        res.status(403).type("text/plain").send("Forbidden");
+        return;
+      }
+    }
+
+    if (!hasTokenMethod) {
+      next();
+      return;
+    }
+
+    const authHeader = req.header("authorization") || "";
+
+    if (config.basicHeader && safeEqual(authHeader, config.basicHeader)) {
+      next();
+      return;
+    }
+
+    if (authHeader.startsWith("Bearer ")) {
+      const token = authHeader.slice("Bearer ".length).trim();
+
+      if (config.bearerToken && safeEqual(token, config.bearerToken)) {
+        next();
+        return;
+      }
+
+      if (config.oauth2 && jwks) {
+        try {
+          const { payload } = await jwtVerify(token, jwks, {
+            audience: config.oauth2.audience,
+            issuer: config.oauth2.issuer,
+            algorithms: config.oauth2.algorithms,
+          });
+          if (config.oauth2.requiredScopes.length > 0) {
+            const tokenScopes = extractScopes(payload);
+            const missing = config.oauth2.requiredScopes.filter(
+              (s) => !tokenScopes.includes(s),
+            );
+            if (missing.length > 0) {
+              logReject(req, `missing scopes: ${missing.join(",")}`);
+              res
+                .status(403)
+                .set(
+                  "WWW-Authenticate",
+                  `Bearer error="insufficient_scope", scope="${config.oauth2.requiredScopes.join(" ")}"`,
+                )
+                .type("text/plain")
+                .send("Forbidden");
+              return;
+            }
+          }
+          next();
+          return;
+        } catch (err) {
+          const code =
+            err instanceof joseErrors.JOSEError ? err.code : "invalid_token";
+          logReject(req, `oauth2 reject: ${code}`);
+          res
+            .status(401)
+            .set("WWW-Authenticate", `Bearer error="invalid_token"`)
+            .type("text/plain")
+            .send("Unauthorized");
+          return;
+        }
+      }
+    }
+
+    logReject(req, "no matching credentials");
+    const challenges: string[] = [];
+    if (config.basicHeader) {
+      challenges.push('Basic realm="metrics"');
+    }
+    if (config.bearerToken || config.oauth2) {
+      challenges.push('Bearer realm="metrics"');
+    }
+    if (challenges.length > 0) {
+      res.set("WWW-Authenticate", challenges.join(", "));
+    }
+    res.status(401).type("text/plain").send("Unauthorized");
+  };
+}


### PR DESCRIPTION
This pull request introduces robust security and configuration improvements to the metrics exporter, focusing on HTTP server hardening, authentication options for the `/metrics` endpoint, and enhanced documentation. The changes provide multiple authentication methods, IP allowlisting, per-endpoint rate limiting, and the option to run `/metrics` on a separate port. The documentation and example environment file are updated to reflect these features.

**Security & Auth Improvements**
- Added four optional authentication methods for `/metrics`: static bearer token, HTTP Basic Auth, OAuth2/OIDC JWT validation, and IP allowlisting, all configurable via environment variables. Multiple methods can be combined, and `/metrics` is public by default unless at least one is enabled. (`src/index.ts`, `middleware/metricsAuth.js`, `.env.example`, `README.md`) [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L1-L38) [[2]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL43-R112) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R107-R121) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R140-R211)
- Introduced per-IP rate limiting for `/metrics` and `/health`, with configurable windows and limits via environment variables. (`src/index.ts`, `.env.example`, `README.md`) [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L1-L38) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R107-R121)

**HTTP Server & Middleware**
- Added HTTP hardening middleware: `helmet` for security headers and `compression` for gzip support. Disabled Express's `x-powered-by` header and set `trust proxy` based on environment variable for accurate client IP detection. (`src/index.ts`, `package.json`, `.env.example`, `README.md`) [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L1-L38) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R26-R32) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R42)
- Added support for running `/metrics` on a dedicated port (`METRICS_PORT`), allowing separation from the main app port for security and operational flexibility. (`src/index.ts`, `.env.example`, `README.md`) [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L1-L38) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R107-R121)

**Documentation & Configuration**
- Updated `.env.example` and `README.md` to document all new environment variables, authentication options, rate limiting, and example Prometheus/Grafana scrape configurations. Added a dedicated section on securing `/metrics`. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL43-R112) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L98-R98) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R107-R121) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R140-R211)

These changes significantly improve the security posture and flexibility of the metrics exporter, making it suitable for both public and enterprise environments.