### PR TITLE
Integration/cd polish

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
   packages: write
   id-token: write # cosign keyless signing via Sigstore
-  attestations: write # GitHub-native build attestations
+  security-events: write # upload-sarif posts to Code Scanning
 
 jobs:
   build:
@@ -39,8 +39,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Single multi-arch build + push. Buildx emits SLSA provenance and
-      # SBOM attestations into the registry automatically.
+      # Single multi-arch build + push.
+      # provenance + sbom are intentionally DISABLED here:
+      #   - they each publish an extra OCI manifest into GHCR ("version"
+      #     entries in the Packages UI) that duplicates work we already do
+      #     via `cosign sign` (signature) and `anchore/sbom-action` (SPDX
+      #     SBOM uploaded as a release artifact).
+      #   - dropping them keeps the registry surface to:
+      #       latest tag + 1 sig + amd64 manifest + arm64 manifest + index
+      #     per push, instead of ~7 entries with attestations on.
       - name: Build and push
         id: push
         uses: docker/build-push-action@v7
@@ -53,8 +60,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          provenance: true
-          sbom: true
+          provenance: false
+          sbom: false
 
       # Sign every published tag with Sigstore keyless cosign.
       # Verifiable downstream via:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,16 +21,38 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       # docker/metadata-action handles latest / version-tag / branch logic
-      # automatically — no more bash heredocs.
+      # automatically — no more bash heredocs. It also generates OCI labels
+      # AND annotations; annotations are required for multi-arch images on
+      # GHCR to display description / source link / license in the UI.
+      # See: https://docs.github.com/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images
       - name: Compute image metadata
         id: meta
         uses: docker/metadata-action@v6
+        env:
+          # Apply annotations to the manifest index (the "fat manifest"
+          # that groups linux/amd64 + linux/arm64). GHCR reads this index
+          # for the package page; without it, description shows as blank.
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index,manifest
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+          labels: |
+            org.opencontainers.image.title=librechat-prom-exporter
+            org.opencontainers.image.description=Prometheus exporter for LibreChat metrics — connects to a LibreChat MongoDB and exposes user, message, conversation, transaction, and cost metrics on /metrics.
+            org.opencontainers.image.vendor=Ruben Talstra
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.documentation=https://github.com/${{ github.repository }}#readme
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}
+          annotations: |
+            org.opencontainers.image.title=librechat-prom-exporter
+            org.opencontainers.image.description=Prometheus exporter for LibreChat metrics — connects to a LibreChat MongoDB and exposes user, message, conversation, transaction, and cost metrics on /metrics.
+            org.opencontainers.image.vendor=Ruben Talstra
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.documentation=https://github.com/${{ github.repository }}#readme
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
@@ -58,6 +80,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,17 @@ RUN npm ci --omit=dev --ignore-scripts --prefer-offline --no-audit --silent && \
 #   - no shell; HEALTHCHECK must use array-form invoking node directly
 FROM cgr.dev/chainguard/node:latest AS runtime
 
+# OCI image metadata. The CD pipeline overrides these via
+# docker/metadata-action so the registry sees commit-pinned values; the
+# defaults here cover local `docker build` and any non-CI consumer.
+LABEL org.opencontainers.image.title="librechat-prom-exporter" \
+      org.opencontainers.image.description="Prometheus exporter for LibreChat metrics — connects to a LibreChat MongoDB and exposes user, message, conversation, transaction, and cost metrics on /metrics." \
+      org.opencontainers.image.vendor="Ruben Talstra" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.source="https://github.com/rubentalstra/librechat-prom-exporter" \
+      org.opencontainers.image.url="https://github.com/rubentalstra/librechat-prom-exporter" \
+      org.opencontainers.image.documentation="https://github.com/rubentalstra/librechat-prom-exporter#readme"
+
 WORKDIR /app
 
 COPY --from=builder --chown=65532:65532 /app/dist ./dist


### PR DESCRIPTION
This pull request updates the container image metadata and the continuous deployment (CD) pipeline to improve the discoverability and quality of published images, especially on GitHub Container Registry (GHCR). The main changes include adding detailed OCI labels and annotations, ensuring these are correctly applied to multi-architecture images, and disabling redundant provenance and SBOM attestations in the CD workflow to reduce registry clutter.

**Container image metadata improvements:**

* Added OCI-compliant labels to the `Dockerfile` with descriptive metadata (title, description, vendor, license, source, URL, documentation) for improved local and non-CI builds.
* Updated the CD workflow (`cd.yml`) to set these labels and annotations dynamically using `docker/metadata-action`, ensuring registry entries are accurate and up-to-date for each build.

**CD workflow and registry publishing changes:**

* Configured `DOCKER_METADATA_ANNOTATIONS_LEVELS` to apply annotations to both the manifest index and individual manifests, ensuring multi-arch images display correct metadata in the GHCR UI.
* Disabled provenance and SBOM generation during the Docker build step to avoid publishing redundant registry entries, streamlining the image registry surface. [[1]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L42-R72) [[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R83-R87)
* Updated permissions in the workflow to use `security-events: write` (for Code Scanning) instead of the deprecated `attestations: write`.