### PR TITLE
feat: enhance GHCR cleanup and attestation processes with new actions and configurations

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,7 +7,8 @@ on:
 permissions:
   contents: read
   packages: write
-  id-token: write # cosign keyless signing via Sigstore
+  id-token: write # cosign keyless signing via Sigstore + GitHub attestations
+  attestations: write # actions/attest-build-provenance + actions/attest-sbom
   security-events: write # upload-sarif posts to Code Scanning
 
 jobs:
@@ -86,6 +87,19 @@ jobs:
           provenance: false
           sbom: false
 
+      # SLSA build provenance via GitHub's native attestation framework.
+      # `push-to-registry: false` keeps the attestation in GitHub's
+      # attestation database (queryable via `gh attestation verify` and
+      # surfaced at https://github.com/<repo>/attestations) WITHOUT
+      # publishing it as an OCI manifest into GHCR — so it doesn't
+      # bloat the Packages page like buildx's `provenance: true` did.
+      - name: Generate SLSA build provenance attestation
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: false
+
       # Sign every published tag with Sigstore keyless cosign.
       # Verifiable downstream via:
       #   cosign verify --certificate-identity-regexp='https://github.com/<repo>/' \
@@ -137,6 +151,19 @@ jobs:
           format: spdx-json
           output-file: sbom.spdx.json
           upload-artifact: true
+
+      # Attest the SBOM via GitHub's native framework. Same logic as
+      # build-provenance above: `push-to-registry: false` keeps it out
+      # of GHCR's OCI manifest list. Consumers verify with:
+      #   gh attestation verify oci://ghcr.io/<repo>:latest \
+      #     --owner <owner> --predicate-type=https://spdx.dev/Document
+      - name: Attest SBOM
+        uses: actions/attest-sbom@v4
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          sbom-path: sbom.spdx.json
+          push-to-registry: false
 
       - name: Attach SBOM to GitHub Release
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,28 @@ jobs:
             depcheck_results.txt
             tsprune_results.txt
           if-no-files-found: ignore
+
+  # Build the Docker image on every PR so Dockerfile regressions surface
+  # at review time, not after merge when CD tries to publish. Single-arch
+  # for speed; CD covers linux/amd64+linux/arm64.
+  docker_build:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build Docker image (no push)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          load: false
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/cleanup-container-versions.yml
+++ b/.github/workflows/cleanup-container-versions.yml
@@ -1,24 +1,32 @@
-name: Cleanup Container Versions
+name: Cleanup GHCR Container Versions
 
-# Deletes orphaned (untagged) container manifest versions from GHCR.
-# Each CD push leaves the previous push's per-platform manifests behind
-# as untagged versions — GHCR never auto-prunes these. Without this job,
-# the Packages UI accumulates `sha256:...` entries indefinitely.
+# Prune untagged orphan manifest digests from GHCR. Replaces the prior
+# actions/delete-package-versions@v5 setup, which is NOT multi-arch-aware
+# (upstream issues #90 and #162 confirm). It would treat per-arch children
+# of a tagged multi-arch index as orphans and delete them — leaving the
+# tagged image un-pullable on the removed architecture.
 #
-# Strategy:
-#   - delete-only-untagged-versions: 'true' protects every tagged release
-#     (latest, v1.2.3, v1.2, etc.) — they are never touched.
-#   - min-versions-to-keep: 20 keeps the 20 most recent versions overall
-#     so a recently-pushed image whose digest hasn't yet been tagged by
-#     a downstream consumer is not yanked from under their feet.
-#   - Cosign signatures (`sha256-<digest>.sig`) and SBOM attestations
-#     are themselves stored under tags (the hyphenated form), so they
-#     are protected by `delete-only-untagged-versions: 'true'`.
+# dataaxiom/ghcr-cleanup-action natively understands:
+#   - multi-arch manifest lists (excludes child images from cleanup)
+#   - cosign signature tags (sha256-<digest>.sig)
+#   - attestation referrers
+# The cleanup algorithm removes those child/referrer images from the
+# working set BEFORE any deletion logic, so per-arch sub-manifests of
+# any tagged index are safe by construction.
 
 on:
   schedule:
     - cron: "0 3 * * 0" # Sunday 03:00 UTC, weekly
-  workflow_dispatch: # also runnable on-demand from the Actions tab
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: "Log only, do not delete"
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
 
 permissions:
   packages: write
@@ -31,10 +39,33 @@ jobs:
   prune:
     runs-on: ubuntu-24.04
     steps:
-      - name: Delete untagged container versions
-        uses: actions/delete-package-versions@v5
+      - name: Cleanup untagged + orphaned referrer images
+        uses: dataaxiom/ghcr-cleanup-action@v1
         with:
-          package-name: librechat-prom-exporter
-          package-type: container
-          min-versions-to-keep: 20
-          delete-only-untagged-versions: "true"
+          # Explicit even though it defaults to repo name; future-proof
+          # against repo rename.
+          package: librechat-prom-exporter
+
+          # Primary cleanup: delete untagged images. Per-arch children of
+          # tagged indexes, cosign sigs, and attestation referrers are
+          # excluded automatically before this rule applies.
+          delete-untagged: true
+
+          # Safety buffer: keep newest 5 truly-untagged digests so an
+          # in-flight push isn't pulled out from under a concurrent
+          # consumer fetch.
+          keep-n-untagged: 5
+
+          # Sweep stranded cosign signature tags (sha256-<digest>.sig)
+          # whose underlying image no longer exists.
+          delete-orphaned-images: true
+
+          # Post-run scan: warn if any multi-arch image is missing a
+          # child platform manifest. Informational; does not fail the job.
+          validate: true
+
+          # Manual runs default to dry-run=true (safe-by-default); the
+          # weekly cron uses dry-run=false.
+          dry-run: ${{ github.event.inputs.dry-run || 'false' }}
+
+          log-level: info

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      packages: read # pull the published image for the weekly scan
+      security-events: write # upload weekly Trivy SARIF to Code Scanning
     # Hoist the secret into a job-level env so step `if:` conditions can
     # reference it. GitHub Actions does not allow `secrets.X` directly in
     # `if:` expressions — `env.X` is the supported pattern.
@@ -38,3 +40,36 @@ jobs:
 
       - name: List outdated dependencies (informational)
         run: npm outdated || true
+
+      # Weekly scan of the PUBLISHED image. Catches CVEs introduced after
+      # the last CD push (e.g., base-image rebuild, new Debian advisory).
+      # Results land in Security → Code scanning under category
+      # `trivy-image-weekly`, separate from CD-time `trivy-image` scans.
+      - name: Log in to GHCR for image pull
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull latest published image
+        run: docker pull ghcr.io/${{ github.repository }}:latest
+
+      - name: Scan published image with Trivy
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ghcr.io/${{ github.repository }}:latest
+          format: sarif
+          output: trivy-image-weekly.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          exit-code: "0"
+
+      - name: Upload weekly Trivy SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-image-weekly.sarif
+          category: trivy-image-weekly
+        continue-on-error: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -134,6 +134,31 @@
         "kuler": "^2.0.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "librechat-prom-exporter",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "librechat-prom-exporter",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@librechat/data-schemas": "^0.0.51",
@@ -49,6 +49,9 @@
         "tsx": "^4.22.3",
         "typescript": "^5.9.3",
         "vitest": "^4.1.6"
+      },
+      "engines": {
+        "node": ">=24"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -129,31 +132,6 @@
         "@so-ric/colorspace": "^1.1.6",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-prom-exporter",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Prometheus exporter for LibreChat metrics",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to improve container image security, supply chain integrity, and maintenance automation. The main changes include enhanced image attestation and SBOM handling, improved multi-architecture container cleanup, proactive Docker build checks in CI, and expanded security scanning of published images.

**Container image attestation and SBOM improvements:**

* Added steps to the `cd.yml` workflow to generate SLSA build provenance attestations and SBOM attestations using GitHub's native attestation framework, keeping them in GitHub's attestation database rather than publishing as OCI manifests, which prevents package bloat and enables easy verification. [[1]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18L10-R11) [[2]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R90-R102) [[3]](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R155-R167)

**Container cleanup automation:**

* Replaced the previous `actions/delete-package-versions` job in `cleanup-container-versions.yml` with `dataaxiom/ghcr-cleanup-action`, which is multi-arch aware and safely prunes untagged/orphaned images, cosign signatures, and attestation referrers without breaking tagged images. Added dry-run support for manual runs and improved documentation. [[1]](diffhunk://#diff-453d89bcbcb55e831dc6e49d7db318db2eb22f272d6720ce16bd9161d43ab7f4L1-R29) [[2]](diffhunk://#diff-453d89bcbcb55e831dc6e49d7db318db2eb22f272d6720ce16bd9161d43ab7f4L34-R71)

**Continuous integration enhancements:**

* Added a `docker_build` job to `ci.yml` to build the Docker image on every PR, surfacing Dockerfile regressions before merge. This builds a single-architecture image for speed, with multi-arch builds still covered in CD.

**Security scanning improvements:**

* Updated `security-audit.yml` to grant permissions for pulling published images and uploading security events. Added a weekly scan of the latest published container image using Trivy, uploading results to GitHub Code Scanning under a separate category (`trivy-image-weekly`). [[1]](diffhunk://#diff-3419faf84cde9b39944015a0edef5b52da2082b5bedf9708e54f527ac360ec5fR12-R13) [[2]](diffhunk://#diff-3419faf84cde9b39944015a0edef5b52da2082b5bedf9708e54f527ac360ec5fR43-R75)