### PR TITLE
ci: update permissions and configurations for SBOM handling in CD pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,7 @@ on:
     tags: ["v*"]
 
 permissions:
-  contents: read
+  contents: write # softprops/action-gh-release attaches SBOM to GitHub Releases on tag push
   packages: write
   id-token: write # cosign keyless signing via Sigstore + GitHub attestations
   attestations: write # actions/attest-build-provenance + actions/attest-sbom
@@ -151,6 +151,11 @@ jobs:
           format: spdx-json
           output-file: sbom.spdx.json
           upload-artifact: true
+          # softprops/action-gh-release below attaches the SBOM to the
+          # GitHub Release on tag pushes. Disabling the action's built-in
+          # release attach avoids a duplicate upload (and avoids needing
+          # contents:write here just for that path).
+          upload-release-assets: false
 
       # Attest the SBOM via GitHub's native framework. Same logic as
       # build-provenance above: `push-to-registry: false` keeps it out


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/cd.yml` to improve how SBOM (Software Bill of Materials) files are handled and to adjust permissions for release automation. The main changes focus on permissions and artifact upload behavior to prevent duplicate SBOM uploads and unnecessary permission grants.

**Permissions and Release Automation:**

* Changed `contents` permission from `read` to `write` to allow `softprops/action-gh-release` to attach the SBOM to GitHub Releases when a tag is pushed.

**SBOM Handling Improvements:**

* Disabled the SBOM upload as a release asset in the SBOM generation step (`upload-release-assets: false`) to avoid duplicate uploads and to prevent requiring `contents:write` permission in this step. The SBOM will instead be attached to the release by the `softprops/action-gh-release` action.