### PR TITLE
fix: update SBOM attestation action and clarify cleanup rules in CI configurations

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -162,8 +162,12 @@ jobs:
       # of GHCR's OCI manifest list. Consumers verify with:
       #   gh attestation verify oci://ghcr.io/<repo>:latest \
       #     --owner <owner> --predicate-type=https://spdx.dev/Document
+      #
+      # actions/attest-sbom was deprecated in favor of the unified
+      # actions/attest action, which detects the SBOM format from the
+      # file passed via `sbom-path` (SPDX or CycloneDX).
       - name: Attest SBOM
-        uses: actions/attest-sbom@v4
+        uses: actions/attest@v4
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/cleanup-container-versions.yml
+++ b/.github/workflows/cleanup-container-versions.yml
@@ -46,14 +46,16 @@ jobs:
           # against repo rename.
           package: librechat-prom-exporter
 
-          # Primary cleanup: delete untagged images. Per-arch children of
-          # tagged indexes, cosign sigs, and attestation referrers are
-          # excluded automatically before this rule applies.
-          delete-untagged: true
-
-          # Safety buffer: keep newest 5 truly-untagged digests so an
-          # in-flight push isn't pulled out from under a concurrent
-          # consumer fetch.
+          # Untagged cleanup: keep the newest 5 truly-untagged digests
+          # and delete the rest. Per-arch children of tagged indexes,
+          # cosign sigs, and attestation referrers are excluded from
+          # the working set BEFORE this rule applies, so they're safe.
+          #
+          # keep-n-untagged and delete-untagged are mutually exclusive
+          # in this action — keep-n-untagged already deletes the
+          # surplus, so delete-untagged must not be set alongside.
+          # The 5-digest buffer prevents an in-flight push from being
+          # pulled out from under a concurrent consumer fetch.
           keep-n-untagged: 5
 
           # Sweep stranded cosign signature tags (sha256-<digest>.sig)


### PR DESCRIPTION
This pull request updates CI/CD workflow files to improve container image management and modernize SBOM attestation. The main changes include switching to the recommended SBOM attestation action and clarifying untagged image cleanup logic to ensure safer and more maintainable container registry operations.

**Workflow improvements:**

* Updated the SBOM attestation step in `.github/workflows/cd.yml` to use the unified `actions/attest` action instead of the deprecated `actions/attest-sbom`, allowing automatic SBOM format detection.

**Container image cleanup enhancements:**

* Replaced the `delete-untagged: true` option with `keep-n-untagged: 5` in `.github/workflows/cleanup-container-versions.yml`, ensuring that only the newest five untagged digests are retained and clarifying that these options are mutually exclusive. Improved comments explain the rationale and safety of this approach.