### PR TITLE
feat(metrics): add cardinality metrics for user tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,14 @@ REFRESH_INTERVAL=30000
 # Defaults to REFRESH_INTERVAL * 10 if unset.
 ADVANCED_REFRESH_INTERVAL=300000
 
+# Time in ms to refresh the high-cardinality (per-user `email`-labeled)
+# metrics. These metrics live in their own scrape loop because their
+# Mongo aggregations and series count grow linearly with users.
+# Defaults to ADVANCED_REFRESH_INTERVAL if unset.
+# Only takes effect when EMIT_PER_USER_METRICS=true — otherwise the
+# scrape is a no-op (no Mongo queries are issued).
+CARDINALITY_REFRESH_INTERVAL=300000
+
 # Mongo connection pool size used by mongoose.connect.
 MONGO_POOL_SIZE=50
 
@@ -28,10 +36,18 @@ LOG_TIMINGS=false
 # metrics remain enabled regardless of this flag.
 # Accepts: 'true' or 'false' (case-insensitive). Any other value fails boot.
 # Affected metrics:
-#   librechat_transaction_cost_by_user{email}
-#   librechat_transaction_token_sum_by_model_user{model,tokenType,email}
-#   librechat_agent_usage_by_user_count{agent,email}
+#   librechat_transaction_cost_by_user{id}
+#   librechat_transaction_token_sum_by_model_user{model,tokenType,id}
+#   librechat_agent_usage_by_user_count{agent,id}
 EMIT_PER_USER_METRICS=false
+
+# Anonymize the `id` label on the per-user (cardinality) metrics above.
+# Default true. When true, the `id` label carries the user's Mongo `_id`
+# (an opaque 24-char ObjectId). When false, the `id` label carries the
+# real email address. The label NAME is always `id` so it fits both
+# shapes.
+# Accepts: 'true' or 'false' (case-insensitive). Any other value fails boot.
+ANONYMIZE_EMAIL_LABEL=true
 
 # Multi-tenant scoping. Leave UNSET on single-tenant LibreChat installs
 # (the default) — all metrics will reflect the whole database, behavior

--- a/package-lock.json
+++ b/package-lock.json
@@ -119,6 +119,7 @@
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
       "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -128,6 +129,7 @@
       "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
       "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@so-ric/colorspace": "^1.1.6",
         "enabled": "2.0.x",
@@ -141,7 +143,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -154,7 +155,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1567,6 +1567,7 @@
       "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
       "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color": "^5.0.2",
         "text-hex": "1.0.x"
@@ -1584,6 +1585,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.44.0.tgz",
       "integrity": "sha512-swSgb7OiPRR3UuIL7NuDrZNSMGmQD+wdtHxPD7j60SvBEnxbXurl5XOirtGEX2gm2hbK6mC8kMV1I+uO3l0UOw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -1818,7 +1820,8 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
@@ -1881,7 +1884,6 @@
       "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.4",
         "@typescript-eslint/types": "8.59.4",
@@ -2132,7 +2134,6 @@
       "integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.6",
@@ -2299,7 +2300,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2552,7 +2552,8 @@
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -2645,7 +2646,6 @@
       "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -2802,7 +2802,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -2949,6 +2950,7 @@
       "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
       "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-convert": "^3.1.3",
         "color-string": "^2.1.3"
@@ -2982,6 +2984,7 @@
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
       "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "^2.0.0"
       },
@@ -2994,6 +2997,7 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
       "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.20"
       }
@@ -3003,6 +3007,7 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
       "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "^2.0.0"
       },
@@ -3015,6 +3020,7 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
       "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.20"
       }
@@ -3166,6 +3172,7 @@
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
       "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-fetch": "^2.7.0"
       }
@@ -3398,6 +3405,7 @@
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -3419,7 +3427,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -3672,7 +3681,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4032,7 +4040,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4163,7 +4170,8 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -4183,6 +4191,7 @@
       "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz",
       "integrity": "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "moment": "^2.29.1"
       }
@@ -4294,7 +4303,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
@@ -5225,6 +5235,7 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -5499,6 +5510,7 @@
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -5510,6 +5522,7 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -5548,7 +5561,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -5569,7 +5583,6 @@
       "resolved": "https://registry.npmjs.org/librechat-data-provider/-/librechat-data-provider-0.8.502.tgz",
       "integrity": "sha512-t88K1SNZ/o/uSK/MyuMfxhLp4FJsf2shxpa855Lbu0jvtiM4HQ0Mau7GJfuJUzZff9ycOirVTc1xiKmyMl7HPA==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "axios": "^1.16.0",
         "dayjs": "^1.11.13",
@@ -5912,44 +5925,49 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -5962,7 +5980,8 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/log-update": {
       "version": "6.1.0",
@@ -6055,6 +6074,7 @@
       "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
       "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@colors/colors": "1.6.0",
         "@types/triple-beam": "^1.3.2",
@@ -6240,6 +6260,7 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -6373,7 +6394,6 @@
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.24.0.tgz",
       "integrity": "sha512-EEZwOibDPZ5uZN3bFapfnRskEbdljAf6sP9ln6u+P4e5IfkOAh6Tqw2g8/Tag++KHOAJ095WXT/c0uqRq4Vckg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bson": "^6.10.4",
         "kareem": "2.6.3",
@@ -6503,7 +6523,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -6588,6 +6607,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -6607,19 +6627,22 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -6630,6 +6653,7 @@
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -6801,6 +6825,7 @@
       "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
       "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fn.name": "1.x.x"
       }
@@ -7379,6 +7404,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -8013,6 +8039,7 @@
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -8078,6 +8105,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -8315,7 +8343,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -8412,6 +8441,7 @@
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
       "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14.0.0"
       }
@@ -8455,7 +8485,6 @@
       "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -8610,7 +8639,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8669,6 +8697,7 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -8684,7 +8713,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -8701,7 +8731,6 @@
       "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -8780,7 +8809,6 @@
       "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.6",
         "@vitest/mocker": "4.1.6",
@@ -9056,6 +9084,7 @@
       "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
       "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "logform": "^2.7.0",
         "readable-stream": "^3.6.2",

--- a/src/config.ts
+++ b/src/config.ts
@@ -71,8 +71,10 @@ const Schema = z
 
     REFRESH_INTERVAL: positiveInt.default(30_000),
     ADVANCED_REFRESH_INTERVAL: positiveInt.optional(),
+    CARDINALITY_REFRESH_INTERVAL: positiveInt.optional(),
 
     EMIT_PER_USER_METRICS: boolish.default(false),
+    ANONYMIZE_EMAIL_LABEL: boolish.default(true),
     TENANT_ID: optionalTrimmed,
 
     TRUST_PROXY: z.string().default("loopback"),
@@ -136,6 +138,7 @@ const Schema = z
 
 export type Config = z.infer<typeof Schema> & {
   ADVANCED_REFRESH_INTERVAL: number;
+  CARDINALITY_REFRESH_INTERVAL: number;
 };
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
@@ -150,7 +153,8 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): Config {
   }
   const data = parsed.data;
   const advanced = data.ADVANCED_REFRESH_INTERVAL ?? data.REFRESH_INTERVAL * 10;
-  return { ...data, ADVANCED_REFRESH_INTERVAL: advanced };
+  const cardinality = data.CARDINALITY_REFRESH_INTERVAL ?? advanced;
+  return { ...data, ADVANCED_REFRESH_INTERVAL: advanced, CARDINALITY_REFRESH_INTERVAL: cardinality };
 }
 
 let cached: Config | undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,13 @@ import { getConfig } from "./config.js";
 import { logger } from "./logger.js";
 import { advancedGauges } from "./metrics/advancedMetrics.js";
 import { basicGauges } from "./metrics/basicMetrics.js";
-import { updateAdvancedMetricsTimed, updateBasicMetricsTimed, waitForIdle } from "./metrics/index.js";
+import { cardinalityGauges } from "./metrics/cardinalityMetrics.js";
+import {
+  updateAdvancedMetricsTimed,
+  updateBasicMetricsTimed,
+  updateCardinalityMetricsTimed,
+  waitForIdle,
+} from "./metrics/index.js";
 import { assertIndexes } from "./metrics/indexAssertions.js";
 import { installTenantHooks } from "./metrics/tenantHooks.js";
 import { buildMetricsAuth } from "./middleware/metricsAuth.js";
@@ -29,6 +35,9 @@ for (const gauge of Object.values(basicGauges)) {
   register.registerMetric(gauge);
 }
 for (const gauge of Object.values(advancedGauges)) {
+  register.registerMetric(gauge as client.Metric);
+}
+for (const gauge of Object.values(cardinalityGauges)) {
   register.registerMetric(gauge as client.Metric);
 }
 
@@ -54,17 +63,20 @@ mongoose
 
 const basicTimer = setInterval(updateBasicMetricsTimed, cfg.REFRESH_INTERVAL);
 const advancedTimer = setInterval(updateAdvancedMetricsTimed, cfg.ADVANCED_REFRESH_INTERVAL);
+const cardinalityTimer = setInterval(updateCardinalityMetricsTimed, cfg.CARDINALITY_REFRESH_INTERVAL);
 if (cfg.LOG_TIMINGS) {
   log.info(
     {
       basicMs: cfg.REFRESH_INTERVAL,
       advancedMs: cfg.ADVANCED_REFRESH_INTERVAL,
+      cardinalityMs: cfg.CARDINALITY_REFRESH_INTERVAL,
     },
     "scheduler started",
   );
 }
 void updateBasicMetricsTimed();
 void updateAdvancedMetricsTimed();
+void updateCardinalityMetricsTimed();
 
 const READY_STATE_LABEL: Record<number, string> = {
   0: "disconnected",
@@ -166,6 +178,7 @@ async function shutdown(signal: NodeJS.Signals): Promise<void> {
   log.info({ signal }, "shutdown signal received — draining");
   clearInterval(basicTimer);
   clearInterval(advancedTimer);
+  clearInterval(cardinalityTimer);
   await Promise.all(servers.map((s) => new Promise<void>((resolve) => s.close(() => resolve()))));
   await waitForIdle();
   try {

--- a/src/metrics/advancedMetrics.ts
+++ b/src/metrics/advancedMetrics.ts
@@ -21,13 +21,11 @@ import {
 
 import { extractEmailDomain } from "./util.js";
 
-// Per-user `email`-labeled metrics are unbounded in cardinality (one series
-// per user, retained by prom-client for the process lifetime). Default off
-// to protect large deployments; set EMIT_PER_USER_METRICS=true to enable.
-function emitPerUser(): boolean {
-  return getConfig().EMIT_PER_USER_METRICS;
-}
-// Domain-level (`*_by_email_domain`) metrics remain on regardless.
+// Per-user `email`-labeled metrics live in `cardinalityGauges` (see
+// ./cardinalityMetrics.ts) and are emitted by their own scrape loop on
+// `CARDINALITY_REFRESH_INTERVAL`. The advanced scrape no longer touches
+// them. Domain-level (`*_by_email_domain`) metrics defined below remain
+// on regardless and are safe by default.
 
 export const advancedGauges = {
   // Message metrics
@@ -253,11 +251,7 @@ export const advancedGauges = {
     help: "Sum of tokens (absolute rawAmount) per model and user email domain",
     labelNames: ["model", "tokenType", "email_domain"],
   }),
-  transactionTokenSumByModelUser: new client.Gauge({
-    name: "librechat_transaction_token_sum_by_model_user",
-    help: "Sum of tokens (absolute rawAmount) per model and user email",
-    labelNames: ["model", "tokenType", "email"],
-  }),
+  // `transactionTokenSumByModelUser` moved to cardinalityGauges.
 
   // Action metrics
   actionCountByType: new client.Gauge({
@@ -282,11 +276,7 @@ export const advancedGauges = {
     help: "Usage count for each agent grouped by user email domain",
     labelNames: ["agent", "email_domain"],
   }),
-  agentUsageByUserCount: new client.Gauge({
-    name: "librechat_agent_usage_by_user_count",
-    help: "Usage count for each agent grouped by user email",
-    labelNames: ["agent", "email"],
-  }),
+  // `agentUsageByUserCount` moved to cardinalityGauges.
   assistantUsageCount: new client.Gauge({
     name: "librechat_assistant_usage_count",
     help: "Usage count for each assistant",
@@ -434,11 +424,7 @@ export const advancedGauges = {
     help: "Total transaction cost in USD grouped by user email domain",
     labelNames: ["email_domain"],
   }),
-  transactionCostByUser: new client.Gauge({
-    name: "librechat_transaction_cost_by_user",
-    help: "Total transaction cost in USD grouped by user email",
-    labelNames: ["email"],
-  }),
+  // `transactionCostByUser` moved to cardinalityGauges.
   transactionCostByAgent: new client.Gauge({
     name: "librechat_transaction_cost_by_agent",
     help: "Total transaction cost in USD grouped by agent (derived from conversations using the agent)",
@@ -1255,19 +1241,11 @@ export async function updateAdvancedMetrics(): Promise<void> {
       tokens: row.tokens,
     }));
 
-    advancedGauges.transactionTokenSumByModelUser.reset();
     advancedGauges.transactionTokenSumByModelDomain.reset();
     const tokensByModelDomain: Map<string, number> = new Map();
     for (const row of tokensByModelUserAgg) {
       const email = row.email || "unknown";
       const emailDomain = extractEmailDomain(email);
-
-      if (emitPerUser()) {
-        advancedGauges.transactionTokenSumByModelUser.set(
-          { model: row.model, tokenType: row.tokenType, email },
-          row.tokens,
-        );
-      }
 
       const domainKey = `${row.model}\u0000${row.tokenType}\u0000${emailDomain}`;
       tokensByModelDomain.set(domainKey, (tokensByModelDomain.get(domainKey) || 0) + row.tokens);
@@ -1305,7 +1283,6 @@ export async function updateAdvancedMetrics(): Promise<void> {
     advancedGauges.agentUsageCount.reset();
     advancedGauges.assistantUsageCount.reset();
     advancedGauges.agentUsageByDomainCount.reset();
-    advancedGauges.agentUsageByUserCount.reset();
 
     for (const result of deployedModelsAgg) {
       const id: string = result._id;
@@ -1352,10 +1329,6 @@ export async function updateAdvancedMetrics(): Promise<void> {
       const agent = agentMap.get(agentId)!;
       const email = userIdToEmail.get(String(row._id.user)) || "unknown";
       const emailDomain = extractEmailDomain(email);
-
-      if (emitPerUser()) {
-        advancedGauges.agentUsageByUserCount.set({ agent, email }, row.count);
-      }
 
       const domainKey = `${agent}|${emailDomain}`;
       agentDomainCounts.set(domainKey, (agentDomainCounts.get(domainKey) || 0) + row.count);
@@ -1743,15 +1716,11 @@ export async function updateAdvancedMetrics(): Promise<void> {
     advancedGauges.transactionCost7d.set(costByWindowAgg?.c7d[0]?.total || 0);
     advancedGauges.transactionCost30d.set(costByWindowAgg?.c30d[0]?.total || 0);
 
-    advancedGauges.transactionCostByUser.reset();
     advancedGauges.transactionCostByEmailDomain.reset();
     const costByDomainMap: Map<string, number> = new Map();
     for (const row of costByDomainUserAgg) {
       const email = userIdToEmail.get(String(row._id)) || "unknown";
       const domain = extractEmailDomain(email);
-      if (emitPerUser()) {
-        advancedGauges.transactionCostByUser.set({ email }, row.cost);
-      }
       costByDomainMap.set(domain, (costByDomainMap.get(domain) || 0) + row.cost);
     }
     for (const [email_domain, cost] of costByDomainMap.entries()) {

--- a/src/metrics/cardinalityMetrics.ts
+++ b/src/metrics/cardinalityMetrics.ts
@@ -1,0 +1,197 @@
+import client from "prom-client";
+
+import { getConfig } from "../config.js";
+import { Agent, Message, Transaction, User } from "../models/index.js";
+
+/**
+ * Cardinality metrics are advanced metrics whose label sets are unbounded in
+ * series count (currently: per-user gauges labeled with `id`). They are
+ * kept in a separate module so operators can reason about (and gate) their
+ * cost independently from the rest of the advanced tier.
+ *
+ * These gauges have their own scrape loop driven by
+ * `CARDINALITY_REFRESH_INTERVAL`, and values are only emitted when
+ * `EMIT_PER_USER_METRICS=true`. When the gate is off,
+ * `updateCardinalityMetrics` is a no-op (no Mongo queries are issued) and
+ * any previously-emitted series are cleared.
+ */
+export function emitPerUser(): boolean {
+  return getConfig().EMIT_PER_USER_METRICS;
+}
+
+/**
+ * When true (default), the per-user cardinality gauges use the user's
+ * Mongo `_id` (ObjectId string) as the `id` label value. When false, the
+ * `id` label carries the user's email address. The label name is always
+ * `id` so it fits both representations.
+ *
+ * Set `ANONYMIZE_EMAIL_LABEL=false` to expose real email addresses (e.g.
+ * for small internal deployments where per-user dashboards by email are
+ * desired).
+ */
+function anonymizeEmailLabel(): boolean {
+  return getConfig().ANONYMIZE_EMAIL_LABEL;
+}
+
+export const cardinalityGauges = {
+  // Total transaction cost in USD per user.
+  transactionCostByUser: new client.Gauge({
+    name: "librechat_transaction_cost_by_user",
+    help: "Total transaction cost in USD grouped by user (id = Mongo _id by default, or email when ANONYMIZE_EMAIL_LABEL=false)",
+    labelNames: ["id"],
+  }),
+
+  // Sum of tokens (absolute rawAmount) per model and user.
+  transactionTokenSumByModelUser: new client.Gauge({
+    name: "librechat_transaction_token_sum_by_model_user",
+    help: "Sum of tokens (absolute rawAmount) per model and user (id = Mongo _id by default, or email when ANONYMIZE_EMAIL_LABEL=false)",
+    labelNames: ["model", "tokenType", "id"],
+  }),
+
+  // Agent usage count per (agent, user) pair.
+  agentUsageByUserCount: new client.Gauge({
+    name: "librechat_agent_usage_by_user_count",
+    help: "Usage count for each agent grouped by user (id = Mongo _id by default, or email when ANONYMIZE_EMAIL_LABEL=false)",
+    labelNames: ["agent", "id"],
+  }),
+};
+
+function resetAll(): void {
+  cardinalityGauges.transactionCostByUser.reset();
+  cardinalityGauges.transactionTokenSumByModelUser.reset();
+  cardinalityGauges.agentUsageByUserCount.reset();
+}
+
+export async function updateCardinalityMetrics(): Promise<void> {
+  // Gated. When disabled the scrape is a complete no-op — no Mongo queries
+  // are issued. Existing series (if any) are cleared so toggling the flag
+  // off is observable on the next scrape.
+  if (!emitPerUser()) {
+    resetAll();
+    return;
+  }
+
+  // --- User map (mongo _id -> label) ---
+  // The label name is always `id` (so it fits both shapes), but the value
+  // is either the user's Mongo `_id` (anonymized, default) or the actual
+  // email address depending on `ANONYMIZE_EMAIL_LABEL`.
+  const anonymize = anonymizeEmailLabel();
+  const userIdToLabel: Map<string, string> = new Map();
+  if (anonymize) {
+    const userDocs = await User.find({}, { _id: 1 }).lean();
+    for (const u of userDocs) {
+      const uid = String(u._id);
+      userIdToLabel.set(uid, uid);
+    }
+  } else {
+    const userDocs = await User.find({}, { email: 1 }).lean();
+    for (const u of userDocs) {
+      userIdToLabel.set(String(u._id), (u.email as string) || "unknown");
+    }
+  }
+
+  // --- Transaction-derived: cost by user, tokens by (model, tokenType, user) ---
+  // Single $facet to avoid scanning Transactions twice.
+  const transactionAggPromise: Promise<
+    Array<{
+      byUser: Array<{ _id: unknown; cost: number }>;
+      byModelUser: Array<{
+        _id: { model: string; user: unknown; tokenType: string };
+        tokens: number;
+      }>;
+    }>
+  > = Transaction.aggregate(
+    [
+      {
+        $project: {
+          user: 1,
+          model: 1,
+          tokenType: 1,
+          rawAmount: 1,
+          tokenValue: 1,
+          createdAt: 1,
+        },
+      },
+      { $addFields: { costUSD: { $divide: [{ $abs: "$tokenValue" }, 1e6] } } },
+      {
+        $facet: {
+          byUser: [{ $group: { _id: "$user", cost: { $sum: "$costUSD" } } }],
+          byModelUser: [
+            {
+              $group: {
+                _id: {
+                  model: "$model",
+                  user: "$user",
+                  tokenType: "$tokenType",
+                },
+                tokens: { $sum: { $abs: "$rawAmount" } },
+              },
+            },
+          ],
+        },
+      },
+    ],
+    { allowDiskUse: true },
+  );
+
+  // --- Message-derived: agent usage by user ---
+  const agentUsageByUserAggPromise: Promise<
+    Array<{
+      _id: { model: string; user: string };
+      count: number;
+    }>
+  > = Message.aggregate(
+    [
+      { $match: { model: { $regex: /^agent_/ } } },
+      {
+        $group: {
+          _id: { model: "$model", user: "$user" },
+          count: { $sum: 1 },
+        },
+      },
+    ],
+    { allowDiskUse: true },
+  );
+
+  const [transactionAgg, agentUsageByUserAgg] = await Promise.all([transactionAggPromise, agentUsageByUserAggPromise]);
+
+  const byUser = transactionAgg[0]?.byUser || [];
+  const byModelUser = transactionAgg[0]?.byModelUser || [];
+
+  // Look up display names for the agents present in the result so labels
+  // match what the advanced tier emits for `librechat_agent_usage_count`.
+  const agentIds = Array.from(new Set(agentUsageByUserAgg.map((row) => row._id.model)));
+  const agents =
+    agentIds.length > 0 ? ((await Agent.find({ id: { $in: agentIds } })) as Array<{ id: string; name?: string }>) : [];
+  const agentMap: Map<string, string> = new Map();
+  for (const a of agents) {
+    agentMap.set(a.id, a.name ? a.name : a.id);
+  }
+
+  // --- Emit ---
+  resetAll();
+
+  for (const row of byUser) {
+    const id = userIdToLabel.get(String(row._id)) || (anonymize ? String(row._id) : "unknown");
+    cardinalityGauges.transactionCostByUser.set({ id }, row.cost);
+  }
+
+  for (const row of byModelUser) {
+    const userId = String(row._id.user);
+    const id = userIdToLabel.get(userId) || (anonymize ? userId : "unknown");
+    cardinalityGauges.transactionTokenSumByModelUser.set(
+      { model: row._id.model, tokenType: row._id.tokenType, id },
+      row.tokens,
+    );
+  }
+
+  for (const row of agentUsageByUserAgg) {
+    const agent = agentMap.get(row._id.model);
+    if (!agent) {
+      continue;
+    }
+    const userId = String(row._id.user);
+    const id = userIdToLabel.get(userId) || (anonymize ? userId : "unknown");
+    cardinalityGauges.agentUsageByUserCount.set({ agent, id }, row.count);
+  }
+}

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -3,6 +3,7 @@ import { logger } from "../logger.js";
 
 import { advancedGauges, updateAdvancedMetrics } from "./advancedMetrics.js";
 import { updateBasicMetrics } from "./basicMetrics.js";
+import { updateCardinalityMetrics } from "./cardinalityMetrics.js";
 
 async function timed(group: string, fn: () => Promise<void>): Promise<void> {
   const log = logger();
@@ -24,6 +25,7 @@ async function timed(group: string, fn: () => Promise<void>): Promise<void> {
 
 let basicRunning = false;
 let advancedRunning = false;
+let cardinalityRunning = false;
 
 export async function updateBasicMetricsTimed(): Promise<void> {
   if (basicRunning) {
@@ -51,14 +53,27 @@ export async function updateAdvancedMetricsTimed(): Promise<void> {
   }
 }
 
+export async function updateCardinalityMetricsTimed(): Promise<void> {
+  if (cardinalityRunning) {
+    logger().warn("cardinality scrape still running, skipping this tick");
+    return;
+  }
+  cardinalityRunning = true;
+  try {
+    await timed("cardinality", updateCardinalityMetrics);
+  } finally {
+    cardinalityRunning = false;
+  }
+}
+
 export async function updateMetrics(): Promise<void> {
-  await Promise.all([updateBasicMetricsTimed(), updateAdvancedMetricsTimed()]);
+  await Promise.all([updateBasicMetricsTimed(), updateAdvancedMetricsTimed(), updateCardinalityMetricsTimed()]);
 }
 
 export async function waitForIdle(timeoutMs = 10_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (!basicRunning && !advancedRunning) {
+    if (!basicRunning && !advancedRunning && !cardinalityRunning) {
       return;
     }
     await new Promise<void>((resolve) => setTimeout(resolve, 100));


### PR DESCRIPTION
## Description

As discussed this PR aims to segregate metrics into 3 layers:
- basic
- advanced
- cardinality

so with that in mind we have new configs so we can, for example, run cardinality twice a day and even hide the "email" of users if that's a requirements.

if ANONYMIZE_EMAIL_LABEL is true, then we return the id instead of email

<img width="1072" height="75" alt="image" src="https://github.com/user-attachments/assets/f2e5c60b-e195-4c15-8af8-feadbe7ae8e6" />

Let me know if there's something else we need changing :)
