### PR TITLE
Add web search usage metrics and dashboard features

### DIFF
--- a/librechat-web-search-dashboard.json
+++ b/librechat-web-search-dashboard.json
@@ -1,0 +1,465 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "11.5.2"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "text",
+      "name": "Text",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Web Search Calls (30d)",
+      "description": "Rolling 30-day window of web search tool calls.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusDS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusDS}"
+          },
+          "editorMode": "code",
+          "expr": "max(librechat_web_search_call_count_30d)",
+          "legendFormat": "Web Search Calls (30d)",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Unique Search Users (30d)",
+      "description": "Distinct users who ran a web search in the last 30 days.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusDS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusDS}"
+          },
+          "editorMode": "code",
+          "expr": "max(librechat_web_search_unique_users_30d)",
+          "legendFormat": "Unique Search Users (30d)",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "All-time Search Calls",
+      "description": "Cumulative web search tool calls since data began.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusDS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusDS}"
+          },
+          "editorMode": "code",
+          "expr": "max(librechat_web_search_call_count)",
+          "legendFormat": "All-time Search Calls",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Adoption (30d)",
+      "description": "Share of active users (30d) who used web search at least once.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusDS}"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusDS}"
+          },
+          "editorMode": "code",
+          "expr": "max(librechat_web_search_unique_users_30d) / clamp_min(max(librechat_unique_users_count_30d), 1) * 100",
+          "legendFormat": "Adoption (30d)",
+          "range": true,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Web Search Activity",
+      "description": "Rolling 30d totals (graphed directly) plus per-interval activity derived from the cumulative all-time gauge.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusDS}"
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 6
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusDS}"
+          },
+          "editorMode": "code",
+          "expr": "max(librechat_web_search_call_count_30d)",
+          "legendFormat": "Calls (rolling 30d)",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusDS}"
+          },
+          "editorMode": "code",
+          "expr": "increase(librechat_web_search_call_count[$__interval])",
+          "legendFormat": "Calls per interval",
+          "range": true,
+          "instant": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheusDS}"
+          },
+          "editorMode": "code",
+          "expr": "max(librechat_web_search_unique_users_30d)",
+          "legendFormat": "Unique users (rolling 30d)",
+          "range": true,
+          "instant": false,
+          "refId": "C"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "text",
+      "title": "Notes",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${prometheusDS}"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "### What this measures\nCounts invocations of the LibreChat `web_search` tool (the **Search** badge / agent tool), recorded as `tool_call` parts in assistant messages.\n\n- **30d gauges** are rolling windows \u2014 graph them directly; do not apply `rate()`/`increase()`.\n- **All-time gauges** are cumulative snapshots \u2014 use `delta()`/`increase()` to see activity within a time window.\n- Excludes provider-native server-side search (Anthropic/OpenAI `web_search` model parameters), which is not recorded in the database.\n\nAll queries use `max()` so they are immune to duplicate exporter replicas during rollouts."
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      }
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 40,
+  "tags": ["LibreChat", "Exporter", "Web Search"],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "includeAll": false,
+        "label": "Prometheus",
+        "multi": false,
+        "name": "prometheusDS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-30d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "LibreChat Web Search",
+  "uid": "librechat-web-search-dashboard",
+  "version": 1,
+  "weekStart": ""
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "librechat-prom-exporter",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Prometheus exporter for LibreChat metrics",
   "main": "dist/index.js",
   "scripts": {

--- a/src/metrics/advancedMetrics.test.ts
+++ b/src/metrics/advancedMetrics.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { sumCreditsByEmailDomain } from "./advancedMetrics.js";
+import { extractWebSearchStats, sumCreditsByEmailDomain } from "./advancedMetrics.js";
 
 describe("sumCreditsByEmailDomain", () => {
   it("sums tokenCredits per email domain", () => {
@@ -42,5 +42,26 @@ describe("sumCreditsByEmailDomain", () => {
 
   it("returns an empty array when there are no balances", () => {
     expect(sumCreditsByEmailDomain([], new Map())).toEqual([]);
+  });
+});
+
+describe("extractWebSearchStats", () => {
+  it("maps populated total and uniqueUsers branches", () => {
+    const facetResult = [{ total: [{ count: 42 }], uniqueUsers: [{ count: 7 }] }];
+
+    expect(extractWebSearchStats(facetResult)).toEqual({ total: 42, uniqueUsers: 7 });
+  });
+
+  it("returns zeros when no web search calls match (empty branches)", () => {
+    expect(extractWebSearchStats([{ total: [], uniqueUsers: [] }])).toEqual({ total: 0, uniqueUsers: 0 });
+  });
+
+  it("tolerates an empty facet result array", () => {
+    expect(extractWebSearchStats([])).toEqual({ total: 0, uniqueUsers: 0 });
+  });
+
+  it("tolerates missing branches and undefined input", () => {
+    expect(extractWebSearchStats([{}])).toEqual({ total: 0, uniqueUsers: 0 });
+    expect(extractWebSearchStats(undefined)).toEqual({ total: 0, uniqueUsers: 0 });
   });
 });

--- a/src/metrics/advancedMetrics.ts
+++ b/src/metrics/advancedMetrics.ts
@@ -331,6 +331,26 @@ export const advancedGauges = {
     help: "Percentage of tool calls that are MCP in the last 30 days",
   }),
 
+  // Web search tool usage (LibreChat `web_search` tool invocations recorded in
+  // message content parts). Excludes provider-native server-side search
+  // (Anthropic/OpenAI addParams), which is opaque to the database.
+  webSearchCallCount: new client.Gauge({
+    name: "librechat_web_search_call_count",
+    help: "Total web search tool calls (all time)",
+  }),
+  webSearchUniqueUsers: new client.Gauge({
+    name: "librechat_web_search_unique_users",
+    help: "Unique users who used the web search tool (all time)",
+  }),
+  webSearchCallCount30d: new client.Gauge({
+    name: "librechat_web_search_call_count_30d",
+    help: "Web search tool calls in the last 30 days",
+  }),
+  webSearchUniqueUsers30d: new client.Gauge({
+    name: "librechat_web_search_unique_users_30d",
+    help: "Unique users who used the web search tool in the last 30 days",
+  }),
+
   // --- Activity & engagement ---
   messagesTotal24h: new client.Gauge({
     name: "librechat_messages_total_24h",
@@ -651,6 +671,21 @@ export function sumCreditsByEmailDomain(
     credits.set(domain, (credits.get(domain) || 0) + (balance.tokenCredits ?? 0));
   }
   return Array.from(credits.entries()).map(([domain, sum]) => ({ domain, credits: sum }));
+}
+
+/**
+ * Maps one `$facet` result with `total: [{ $count }]` and
+ * `uniqueUsers: [{ $group: "$user" }, { $count }]` branches into a plain
+ * `{ total, uniqueUsers }` pair. Tolerates an empty/missing facet result
+ * (no matching tool calls) by returning zeros. Used for the web search
+ * gauges from both the all-time and 30-day aggregations.
+ */
+export function extractWebSearchStats(facetResult: unknown): { total: number; uniqueUsers: number } {
+  const row = (facetResult as Array<Record<string, Array<{ count?: number }>>> | undefined)?.[0];
+  return {
+    total: row?.total?.[0]?.count ?? 0,
+    uniqueUsers: row?.uniqueUsers?.[0]?.count ?? 0,
+  };
 }
 
 export async function updateAdvancedMetrics(): Promise<void> {
@@ -1362,7 +1397,7 @@ export async function updateAdvancedMetrics(): Promise<void> {
     __mark("Parallelized: Feedback, Distinct Models, MCP (independent queries)");
 
     // --- Parallelized: Feedback, Distinct Models, MCP (independent queries) ---
-    const [feedbackByModel30dAgg, distinctModelsAgg, toolCallContentAgg] = await Promise.all([
+    const [feedbackByModel30dAgg, distinctModelsAgg, toolCallContentAgg, webSearchAllTimeAgg] = await Promise.all([
       // Feedback by model/agent (30d) — only assistant messages are eligible
       Message.aggregate([
         {
@@ -1419,9 +1454,42 @@ export async function updateAdvancedMetrics(): Promise<void> {
               { $group: { _id: "$user" } },
               { $count: "count" },
             ],
+            webSearchTotal: [{ $match: { toolName: "web_search" } }, { $count: "count" }],
+            webSearchUniqueUsers: [
+              { $match: { toolName: "web_search" } },
+              { $group: { _id: "$user" } },
+              { $count: "count" },
+            ],
           },
         },
       ]),
+      // Web search tool usage (all time). `web_search` invocations are
+      // recorded as message content parts, so this scans the (large,
+      // unbounded-by-date) messages collection; `allowDiskUse` keeps the
+      // $unwind off the wire memory limit. Runs in parallel with the 30d
+      // aggregation above rather than adding a serial round trip.
+      Message.aggregate(
+        [
+          { $match: { "content.type": "tool_call" } },
+          { $unwind: "$content" },
+          { $match: { "content.type": "tool_call" } },
+          {
+            $addFields: {
+              toolName: {
+                $ifNull: ["$content.tool_call.name", { $ifNull: ["$content.tool_call.function.name", "unknown"] }],
+              },
+            },
+          },
+          { $match: { toolName: "web_search" } },
+          {
+            $facet: {
+              total: [{ $count: "count" }],
+              uniqueUsers: [{ $group: { _id: "$user" } }, { $count: "count" }],
+            },
+          },
+        ],
+        { allowDiskUse: true },
+      ),
     ]);
 
     __mark("Feedback Percentage + Net Satisfaction by Model / Agent (30 days)");
@@ -1501,6 +1569,26 @@ export async function updateAdvancedMetrics(): Promise<void> {
 
     advancedGauges.mcpUniqueUserCount30d.set(mcpUsers);
     advancedGauges.mcpUtilizationPercent30d.set(toPercent(mcpTotal, totalToolCalls30d));
+
+    __mark("Web Search Usage Metrics");
+
+    // --- Web Search Usage Metrics ---
+    // 30d stats ride the shared toolCallContentAgg $facet (no extra scan);
+    // all-time stats come from the dedicated aggregation added to the same
+    // parallel batch. Both use the same branch shape (total + uniqueUsers),
+    // so a single helper maps them.
+    const webSearch30d = extractWebSearchStats([
+      {
+        total: toolCallContentAgg[0]?.webSearchTotal,
+        uniqueUsers: toolCallContentAgg[0]?.webSearchUniqueUsers,
+      },
+    ]);
+    advancedGauges.webSearchCallCount30d.set(webSearch30d.total);
+    advancedGauges.webSearchUniqueUsers30d.set(webSearch30d.uniqueUsers);
+
+    const webSearchAllTime = extractWebSearchStats(webSearchAllTimeAgg);
+    advancedGauges.webSearchCallCount.set(webSearchAllTime.total);
+    advancedGauges.webSearchUniqueUsers.set(webSearchAllTime.uniqueUsers);
 
     // ============================================================
     // === Extended metrics (Activity, Quality, Cost, Agents...) ===

--- a/website/docs/reference/metrics.mdx
+++ b/website/docs/reference/metrics.mdx
@@ -129,6 +129,17 @@ Source: `src/metrics/advancedMetrics.ts`. ~60 metrics grouped here.
 | `librechat_mcp_unique_users_by_tool_30d`     | gauge | `toolId`                 | Distinct users per MCP tool.          |
 | `librechat_mcp_tool_call_by_user_domain_30d` | gauge | `toolId`, `email_domain` | Per-tool, per-domain breakdown.       |
 
+### Web search
+
+Counts LibreChat `web_search` tool invocations recorded in message content parts (the Search badge / agent tool). Excludes provider-native server-side search (Anthropic/OpenAI `web_search` addParams), which is opaque to the database.
+
+| Metric                                  | Type  | Labels | Notes                                |
+| --------------------------------------- | ----- | ------ | ------------------------------------ |
+| `librechat_web_search_call_count`       | gauge | —      | Web search tool calls (all time).    |
+| `librechat_web_search_unique_users`     | gauge | —      | Distinct users (all time).           |
+| `librechat_web_search_call_count_30d`   | gauge | —      | Web search tool calls, last 30 days. |
+| `librechat_web_search_unique_users_30d` | gauge | —      | Distinct users, last 30 days.        |
+
 ### Files
 
 | Metric                                         | Type  | Labels         | Notes                                       |


### PR DESCRIPTION
This pull request adds new Prometheus metrics to track usage of the LibreChat `web_search` tool, including both all-time and 30-day statistics. It introduces new aggregation logic, helper functions, and documentation to support these metrics, along with comprehensive tests for the new functionality.

**Web search usage metrics:**

- Added four new gauges to `advancedGauges` in `advancedMetrics.ts` to record total web search tool calls and unique users, both all-time and in the last 30 days.
- Implemented new MongoDB aggregations to efficiently collect all-time and 30-day web search tool usage statistics, using `$facet` pipelines and parallelized queries. [[1]](diffhunk://#diff-766c5b7c9b8321533fffd3acde84eed89b0bd135bf3178547ef23a85cd473c06R1457-R1492) [[2]](diffhunk://#diff-766c5b7c9b8321533fffd3acde84eed89b0bd135bf3178547ef23a85cd473c06L1365-R1400)
- Added the `extractWebSearchStats` helper function to map aggregation results into `{ total, uniqueUsers }` objects, handling empty and missing data gracefully.
- Integrated the new metrics into the `updateAdvancedMetrics` function, updating the gauges with the latest values from the aggregations.

**Testing and documentation:**

- Added a new test suite for `extractWebSearchStats` in `advancedMetrics.test.ts`, covering normal, empty, and malformed input cases.
- Documented the new metrics in `metrics.mdx`, explaining their meaning and limitations.

(Package version bumped to `0.10.3` to reflect these changes.)

### Sample

<img width="1873" height="952" alt="image" src="https://github.com/user-attachments/assets/dd7a89da-0e60-4738-bdf9-6c01424a704a" />